### PR TITLE
feat(setup): standing prose-contract line in the installed docs snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the flow-next.
 
+## Unreleased
+
+### Changed
+
+- **The installed docs snippet now names the prose contract for chat replies.** 4.7.1 moved `/flow-next:prose` to the drafting moment, but the trigger stayed opportunistic — a host that never consulted its skill catalog could still ship a multi-section reply outside the contract. The CLAUDE.md/AGENTS.md block that `/flow-next:setup` writes now carries a one-line standing instruction: invoke the prose skill before drafting any substantial reply; short conversational turns skip it. Snippet sentinel bumped to `v2`. Upgrade action: existing repos pick the line up on their next `/flow-next:setup` run (the Docs step proposes a marker-bounded refresh on content drift); nothing breaks unrefreshed.
+
 ## [flow-next 4.7.1] - 2026-08-28
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,7 @@ This project uses Flow-Next for ALL task tracking. `flowctl` comes from the flow
 - BEFORE any other flowctl operation, or when unsure of a flag: run `flowctl usage` (CLI cheatsheet + orchestration recipes) or `flowctl --help`.
 - BEFORE bridging work to another model/CLI (`codex exec`, `cursor-agent`, `claude -p`, `grok`) or picking an implementation/review model: run `flowctl usage` and follow "Orchestration & model steering" exactly.
 - Creating a spec: write it directly — `/flow-next:plan` is task breakdown only. `flowctl spec create --title "Short title" --plan-file plan.md --json`, then `/flow-next:plan <spec-id>`. Scaffold cascade (first match wins): `SPEC.md` -> `spec.md` -> bundled template.
+- Substantial replies (reports, reviews, multi-section answers): invoke `/flow-next:prose` BEFORE drafting — the artifact prose contract applies to chat replies too. Short conversational turns skip it.
 - If `flowctl` is not found: your shell lacks the plugin's `scripts/` dir on PATH (only Claude Code injects it). Resolve it the way the skills do - the plugin install's `scripts/flowctl` (Claude/Droid: plugin-root env var; Codex: `${CODEX_HOME:-$HOME/.codex}/scripts/flowctl`; Cursor/Grok: two levels above any flow-next SKILL.md) - or update/reinstall the flow-next plugin. A repo with no `.flow/` yet: run `/flow-next:setup`.
 
 **This repo's own additions (maintainer notes, not part of the shipped snippet):**

--- a/plugins/flow-next/codex/skills/flow-next-setup/templates/agents-md-snippet.md
+++ b/plugins/flow-next/codex/skills/flow-next-setup/templates/agents-md-snippet.md
@@ -1,5 +1,5 @@
 <!-- BEGIN FLOW-NEXT -->
-<!-- flow-next:snippet:v1 -->
+<!-- flow-next:snippet:v2 -->
 ## Flow-Next
 
 This project uses Flow-Next for ALL task tracking. `flowctl` comes from the flow-next plugin install — every flow-next skill resolves it itself, and on Claude Code it is also on PATH. Do NOT create markdown TODOs or use TodoWrite. Cold session: `flowctl brief` first — one bounded call (specs, ready tasks, memory); go deeper with `show`/`cat`/`anchor <task-id>`.
@@ -8,5 +8,6 @@ This project uses Flow-Next for ALL task tracking. `flowctl` comes from the flow
 - BEFORE any other flowctl operation, or when unsure of a flag: run `flowctl usage` (CLI cheatsheet + orchestration recipes) or `flowctl --help`.
 - BEFORE bridging work to another model/CLI (`codex exec`, `cursor-agent`, `claude -p`, `grok`) or picking an implementation/review model: run `flowctl usage` and follow "Orchestration & model steering" exactly.
 - Creating a spec: write it directly — `$flow-next-plan` is task breakdown only. `flowctl spec create --title "Short title" --plan-file plan.md --json`, then `$flow-next-plan <spec-id>`. Scaffold cascade (first match wins): `SPEC.md` -> `spec.md` -> bundled template.
+- Substantial replies (reports, reviews, multi-section answers): invoke `$flow-next-prose` BEFORE drafting — the artifact prose contract applies to chat replies too. Short conversational turns skip it.
 - If `flowctl` is not found: your shell lacks the plugin's `scripts/` dir on PATH (only Claude Code injects it). Resolve it the way the skills do - the plugin install's `scripts/flowctl` (Claude/Droid: plugin-root env var; Codex: `${CODEX_HOME:-$HOME/.codex}/scripts/flowctl`; Cursor/Grok: two levels above any flow-next SKILL.md) - or update/reinstall the flow-next plugin. A repo with no `.flow/` yet: run `$flow-next-setup`.
 <!-- END FLOW-NEXT -->

--- a/plugins/flow-next/codex/skills/flow-next-setup/templates/claude-md-snippet.md
+++ b/plugins/flow-next/codex/skills/flow-next-setup/templates/claude-md-snippet.md
@@ -1,5 +1,5 @@
 <!-- BEGIN FLOW-NEXT -->
-<!-- flow-next:snippet:v1 -->
+<!-- flow-next:snippet:v2 -->
 ## Flow-Next
 
 This project uses Flow-Next for ALL task tracking. `flowctl` comes from the flow-next plugin install — every flow-next skill resolves it itself, and on Claude Code it is also on PATH. Do NOT create markdown TODOs or use TodoWrite. Cold session: `flowctl brief` first — one bounded call (specs, ready tasks, memory); go deeper with `show`/`cat`/`anchor <task-id>`.
@@ -8,5 +8,6 @@ This project uses Flow-Next for ALL task tracking. `flowctl` comes from the flow
 - BEFORE any other flowctl operation, or when unsure of a flag: run `flowctl usage` (CLI cheatsheet + orchestration recipes) or `flowctl --help`.
 - BEFORE bridging work to another model/CLI (`codex exec`, `cursor-agent`, `claude -p`, `grok`) or picking an implementation/review model: run `flowctl usage` and follow "Orchestration & model steering" exactly.
 - Creating a spec: write it directly — `/flow-next:plan` is task breakdown only. `flowctl spec create --title "Short title" --plan-file plan.md --json`, then `/flow-next:plan <spec-id>`. Scaffold cascade (first match wins): `SPEC.md` -> `spec.md` -> bundled template.
+- Substantial replies (reports, reviews, multi-section answers): invoke `/flow-next:prose` BEFORE drafting — the artifact prose contract applies to chat replies too. Short conversational turns skip it.
 - If `flowctl` is not found: your shell lacks the plugin's `scripts/` dir on PATH (only Claude Code injects it). Resolve it the way the skills do - the plugin install's `scripts/flowctl` (Claude/Droid: plugin-root env var; Codex: `${CODEX_HOME:-$HOME/.codex}/scripts/flowctl`; Cursor/Grok: two levels above any flow-next SKILL.md) - or update/reinstall the flow-next plugin. A repo with no `.flow/` yet: run `/flow-next:setup`.
 <!-- END FLOW-NEXT -->

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -19926,10 +19926,10 @@ def cmd_usage(args: argparse.Namespace) -> None:
 
 # fn-121/fn-197: the snippet sentinel version, as a documented anchor only.
 # No code reads these since fn-197 deleted the setup-mode pre-check blocks -
-# they exist so the template's `<!-- flow-next:snippet:v1 -->` sentinel has a
+# they exist so the template's `<!-- flow-next:snippet:v2 -->` sentinel has a
 # named source of truth. Bumping the version is a doc/template decision (the
 # setup Docs step re-proposes on CONTENT drift, not on this number).
-SNIPPET_SCHEMA_VERSION = 1
+SNIPPET_SCHEMA_VERSION = 2
 # fn-197: the machine-readable manifest of legacy copy-mode artifacts — the
 # single source of truth for /flow-next:setup's and /flow-next:plan's residue
 # probes. Copy-less installs write none of these; a repo that still carries

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "d2785aaa7e99ae43dcce337db855e0a9680db75104e8e95c545a8dc35c6b0c64"
+      "sha256": "f38781ecf351bcaef2b29f16920d89767f02148c1ecc4a180b3f36a0dc35e2f1"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/skills/flow-next-setup/templates/agents-md-snippet.md
+++ b/plugins/flow-next/skills/flow-next-setup/templates/agents-md-snippet.md
@@ -1,5 +1,5 @@
 <!-- BEGIN FLOW-NEXT -->
-<!-- flow-next:snippet:v1 -->
+<!-- flow-next:snippet:v2 -->
 ## Flow-Next
 
 This project uses Flow-Next for ALL task tracking. `flowctl` comes from the flow-next plugin install — every flow-next skill resolves it itself, and on Claude Code it is also on PATH. Do NOT create markdown TODOs or use TodoWrite. Cold session: `flowctl brief` first — one bounded call (specs, ready tasks, memory); go deeper with `show`/`cat`/`anchor <task-id>`.
@@ -8,5 +8,6 @@ This project uses Flow-Next for ALL task tracking. `flowctl` comes from the flow
 - BEFORE any other flowctl operation, or when unsure of a flag: run `flowctl usage` (CLI cheatsheet + orchestration recipes) or `flowctl --help`.
 - BEFORE bridging work to another model/CLI (`codex exec`, `cursor-agent`, `claude -p`, `grok`) or picking an implementation/review model: run `flowctl usage` and follow "Orchestration & model steering" exactly.
 - Creating a spec: write it directly — `$flow-next-plan` is task breakdown only. `flowctl spec create --title "Short title" --plan-file plan.md --json`, then `$flow-next-plan <spec-id>`. Scaffold cascade (first match wins): `SPEC.md` -> `spec.md` -> bundled template.
+- Substantial replies (reports, reviews, multi-section answers): invoke `$flow-next-prose` BEFORE drafting — the artifact prose contract applies to chat replies too. Short conversational turns skip it.
 - If `flowctl` is not found: your shell lacks the plugin's `scripts/` dir on PATH (only Claude Code injects it). Resolve it the way the skills do - the plugin install's `scripts/flowctl` (Claude/Droid: plugin-root env var; Codex: `${CODEX_HOME:-$HOME/.codex}/scripts/flowctl`; Cursor/Grok: two levels above any flow-next SKILL.md) - or update/reinstall the flow-next plugin. A repo with no `.flow/` yet: run `$flow-next-setup`.
 <!-- END FLOW-NEXT -->

--- a/plugins/flow-next/skills/flow-next-setup/templates/claude-md-snippet.md
+++ b/plugins/flow-next/skills/flow-next-setup/templates/claude-md-snippet.md
@@ -1,5 +1,5 @@
 <!-- BEGIN FLOW-NEXT -->
-<!-- flow-next:snippet:v1 -->
+<!-- flow-next:snippet:v2 -->
 ## Flow-Next
 
 This project uses Flow-Next for ALL task tracking. `flowctl` comes from the flow-next plugin install — every flow-next skill resolves it itself, and on Claude Code it is also on PATH. Do NOT create markdown TODOs or use TodoWrite. Cold session: `flowctl brief` first — one bounded call (specs, ready tasks, memory); go deeper with `show`/`cat`/`anchor <task-id>`.
@@ -8,5 +8,6 @@ This project uses Flow-Next for ALL task tracking. `flowctl` comes from the flow
 - BEFORE any other flowctl operation, or when unsure of a flag: run `flowctl usage` (CLI cheatsheet + orchestration recipes) or `flowctl --help`.
 - BEFORE bridging work to another model/CLI (`codex exec`, `cursor-agent`, `claude -p`, `grok`) or picking an implementation/review model: run `flowctl usage` and follow "Orchestration & model steering" exactly.
 - Creating a spec: write it directly — `/flow-next:plan` is task breakdown only. `flowctl spec create --title "Short title" --plan-file plan.md --json`, then `/flow-next:plan <spec-id>`. Scaffold cascade (first match wins): `SPEC.md` -> `spec.md` -> bundled template.
+- Substantial replies (reports, reviews, multi-section answers): invoke `/flow-next:prose` BEFORE drafting — the artifact prose contract applies to chat replies too. Short conversational turns skip it.
 - If `flowctl` is not found: your shell lacks the plugin's `scripts/` dir on PATH (only Claude Code injects it). Resolve it the way the skills do - the plugin install's `scripts/flowctl` (Claude/Droid: plugin-root env var; Codex: `${CODEX_HOME:-$HOME/.codex}/scripts/flowctl`; Cursor/Grok: two levels above any flow-next SKILL.md) - or update/reinstall the flow-next plugin. A repo with no `.flow/` yet: run `/flow-next:setup`.
 <!-- END FLOW-NEXT -->


### PR DESCRIPTION
## Summary

The `/flow-next:prose` drafting-moment behavior shipped in 4.7.1 is description-triggered and therefore opportunistic — a host can still draft a multi-section reply without consulting the skill catalog (observed on Claude Code, 2026-08-28). This adds a one-line standing instruction to the docs snippet that `/flow-next:setup` installs, making the contract a repo-level rule instead of a catalog hint.

## What changed

- `claude-md-snippet.md` / `agents-md-snippet.md`: new bullet — invoke `/flow-next:prose` (`$flow-next-prose` twin) before drafting substantial replies; short conversational turns skip it. Sentinel bumped `v1` → `v2`.
- `flowctl.py`: `SNIPPET_SCHEMA_VERSION = 2` (documented anchor; no code reads it — setup's Docs step re-proposes on content drift).
- Repo's own `CLAUDE.md` Flow-Next block: same line, so this repo doesn't re-run setup.
- Codex mirror regenerated (`sync-codex.sh` twice, idempotent); tracker manifest regenerated.
- CHANGELOG: `## Unreleased` entry with the upgrade action.

## Verification

- `python3 scripts/run_tests_parallel.py` — 4505 ran, 0 failures (includes `test_setup_snippet_lockstep`, `test_tracker_distribution`)
- `uvx ruff@0.16.0 check .` — clean
- `./scripts/sync-codex.sh` run twice — idempotent, guards green

## Version note

No version bump — staged under `## Unreleased` per the batched-release rule.

https://claude.ai/code/session_0197ehG7tJuDZpbrn7JsTAyg