### PR TITLE
chore(flow): plan fn-209 no-plan work route + tool-permission audit

### DIFF
--- a/.flow/specs/fn-209-no-plan-work-route-tool-permission-audit.json
+++ b/.flow/specs/fn-209-no-plan-work-route-tool-permission-audit.json
@@ -1,11 +1,348 @@
 {
   "branch_name": "fn-209-no-plan-work-route-tool-permission-audit",
+  "completion_review_status": "unknown",
+  "completion_reviewed_at": null,
   "created_at": "2026-08-28T20:55:22.515162Z",
-  "depends_on_epics": [],
+  "default_impl": null,
+  "default_review": null,
+  "default_sync": null,
+  "depends_on_epics": [
+    "fn-208-hardening-pass-worker-review-and"
+  ],
   "id": "fn-209-no-plan-work-route-tool-permission-audit",
+  "impl_review_rounds": {},
   "next_task": 1,
-  "plan_review_status": "unknown",
-  "plan_reviewed_at": null,
+  "plan_review_rounds": 0,
+  "plan_review_status": "ship",
+  "plan_reviewed_at": "2026-08-28T22:07:56.223626Z",
+  "review_attempts": [
+    {
+      "artifact_sha256": "9ff3b4c997695cb056d9402fd41772dc2989f87e8d85d2f549feb763eb9efd34",
+      "backend": "codex",
+      "base_sha": "b488ad805b33bb8e664ad9265d47781f238e782a",
+      "counter_kind": "plan",
+      "effort": "high",
+      "failure_class": null,
+      "finalized": {
+        "digest": "complete",
+        "receipt": "complete",
+        "status": "complete"
+      },
+      "findings_digest": {
+        "backend": "codex",
+        "digest_truncated": false,
+        "items": [
+          {
+            "chainRoot": "finding-e00d34a09db9399f4ec1a660969a63b4",
+            "classification": "introduced",
+            "findingId": "finding-e00d34a09db9399f4ec1a660969a63b4",
+            "firstSeenThisRound": true,
+            "severity": "P0",
+            "status": "open"
+          },
+          {
+            "chainRoot": "finding-3c9e7697aadc7dc792d81d1f831e8d9f",
+            "classification": "introduced",
+            "findingId": "finding-3c9e7697aadc7dc792d81d1f831e8d9f",
+            "firstSeenThisRound": true,
+            "severity": "P1",
+            "status": "open"
+          },
+          {
+            "chainRoot": "finding-b89f82c95f673fddd7e8945d7c10afd9",
+            "classification": "introduced",
+            "findingId": "finding-b89f82c95f673fddd7e8945d7c10afd9",
+            "firstSeenThisRound": true,
+            "severity": "P1",
+            "status": "open"
+          },
+          {
+            "chainRoot": "finding-6acf7521e93730a680f66dad083818af",
+            "classification": "introduced",
+            "findingId": "finding-6acf7521e93730a680f66dad083818af",
+            "firstSeenThisRound": true,
+            "severity": "P1",
+            "status": "open"
+          },
+          {
+            "chainRoot": "finding-f1eb596cd76a38e421dfc8195c11c371",
+            "classification": "introduced",
+            "findingId": "finding-f1eb596cd76a38e421dfc8195c11c371",
+            "firstSeenThisRound": true,
+            "severity": "P1",
+            "status": "open"
+          },
+          {
+            "chainRoot": "finding-fadfd735dce642f3fa2b6bcb0e03defe",
+            "classification": "introduced",
+            "findingId": "finding-fadfd735dce642f3fa2b6bcb0e03defe",
+            "firstSeenThisRound": true,
+            "severity": "P1",
+            "status": "open"
+          },
+          {
+            "chainRoot": "finding-9fa6186352f18dfe6269baa691d59765",
+            "classification": "introduced",
+            "findingId": "finding-9fa6186352f18dfe6269baa691d59765",
+            "firstSeenThisRound": true,
+            "severity": "P1",
+            "status": "open"
+          },
+          {
+            "chainRoot": "finding-b1c5cb287ae47b3772e45fc93ddfebc9",
+            "classification": "introduced",
+            "findingId": "finding-b1c5cb287ae47b3772e45fc93ddfebc9",
+            "firstSeenThisRound": true,
+            "severity": "P2",
+            "status": "open"
+          }
+        ],
+        "reviewKind": "plan"
+      },
+      "forced": false,
+      "hash_epoch": 0,
+      "head_sha": "791a7e4c3934fd3495dd0cf2e5bbf7287603d568",
+      "head_sha_observed": true,
+      "kind": "plan",
+      "model": "gpt-5.6-sol",
+      "outcome": "verdict",
+      "output_bytes": 789560,
+      "output_sha256": "2ce3c8ddba4642c6f69be9c3805bed9aa4fedfd5be55741481f4e935c4176a7a",
+      "reservation_id": "faa1b713357c4995a25f8df086cb1dee",
+      "round_consumed": true,
+      "scope": "plan",
+      "superseded_by": null,
+      "task": null,
+      "timestamp": "2026-08-28T22:04:09.582471Z",
+      "tool_calls": 18,
+      "verdict": "NEEDS_WORK"
+    },
+    {
+      "artifact_sha256": "2e76c7263937e6c411c1a806b8934064b6f84a108d42b4197d917c60ee862eac",
+      "backend": "codex",
+      "base_sha": "b488ad805b33bb8e664ad9265d47781f238e782a",
+      "counter_kind": "plan",
+      "effort": "high",
+      "failure_class": null,
+      "finalized": {
+        "digest": "complete",
+        "receipt": "complete",
+        "status": "complete"
+      },
+      "findings_digest": {
+        "backend": "codex",
+        "digest_truncated": false,
+        "items": [
+          {
+            "chainRoot": "finding-e00d34a09db9399f4ec1a660969a63b4",
+            "classification": "introduced",
+            "findingId": "finding-e00d34a09db9399f4ec1a660969a63b4",
+            "firstSeenThisRound": false,
+            "severity": "P0",
+            "status": "not_fixed"
+          },
+          {
+            "chainRoot": "finding-3c9e7697aadc7dc792d81d1f831e8d9f",
+            "classification": "introduced",
+            "findingId": "finding-3c9e7697aadc7dc792d81d1f831e8d9f",
+            "firstSeenThisRound": false,
+            "severity": "P1",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-b89f82c95f673fddd7e8945d7c10afd9",
+            "classification": "introduced",
+            "findingId": "finding-b89f82c95f673fddd7e8945d7c10afd9",
+            "firstSeenThisRound": false,
+            "severity": "P1",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-6acf7521e93730a680f66dad083818af",
+            "classification": "introduced",
+            "findingId": "finding-6acf7521e93730a680f66dad083818af",
+            "firstSeenThisRound": false,
+            "severity": "P1",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-f1eb596cd76a38e421dfc8195c11c371",
+            "classification": "introduced",
+            "findingId": "finding-f1eb596cd76a38e421dfc8195c11c371",
+            "firstSeenThisRound": false,
+            "severity": "P1",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-fadfd735dce642f3fa2b6bcb0e03defe",
+            "classification": "introduced",
+            "findingId": "finding-fadfd735dce642f3fa2b6bcb0e03defe",
+            "firstSeenThisRound": false,
+            "severity": "P1",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-cb3d8591ec065b6883bbf7e24be34668",
+            "classification": "introduced",
+            "findingId": "finding-cb3d8591ec065b6883bbf7e24be34668",
+            "firstSeenThisRound": true,
+            "severity": "P1",
+            "status": "open"
+          },
+          {
+            "chainRoot": "finding-9fa6186352f18dfe6269baa691d59765",
+            "classification": "introduced",
+            "findingId": "finding-9fa6186352f18dfe6269baa691d59765",
+            "firstSeenThisRound": false,
+            "severity": "P1",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-b1c5cb287ae47b3772e45fc93ddfebc9",
+            "classification": "introduced",
+            "findingId": "finding-b1c5cb287ae47b3772e45fc93ddfebc9",
+            "firstSeenThisRound": false,
+            "severity": "P2",
+            "status": "fixed"
+          }
+        ],
+        "reviewKind": "plan"
+      },
+      "forced": false,
+      "hash_epoch": 0,
+      "head_sha": "791a7e4c3934fd3495dd0cf2e5bbf7287603d568",
+      "head_sha_observed": true,
+      "kind": "plan",
+      "model": "gpt-5.6-sol",
+      "outcome": "verdict",
+      "output_bytes": 975,
+      "output_sha256": "1638681b88dd4fa869fc5b22be1b3784da4d53a84b5e49a813e5bc8787310b6e",
+      "reservation_id": "02499f7fddb24be7987b7c46a99ecfbd",
+      "round_consumed": true,
+      "scope": "plan",
+      "superseded_by": null,
+      "task": null,
+      "timestamp": "2026-08-28T22:07:19.139759Z",
+      "verdict": "NEEDS_WORK"
+    },
+    {
+      "artifact_sha256": "d96661d0d51c49d136571ba908ca3f199be01e67e42ea215c4751a4bd38e3bad",
+      "backend": "codex",
+      "base_sha": "b488ad805b33bb8e664ad9265d47781f238e782a",
+      "counter_kind": "plan",
+      "effort": "high",
+      "failure_class": null,
+      "finalized": {
+        "digest": "complete",
+        "receipt": "complete",
+        "status": "complete"
+      },
+      "findings_digest": {
+        "backend": "codex",
+        "digest_truncated": false,
+        "items": [
+          {
+            "chainRoot": "finding-e00d34a09db9399f4ec1a660969a63b4",
+            "classification": "introduced",
+            "findingId": "finding-e00d34a09db9399f4ec1a660969a63b4",
+            "firstSeenThisRound": false,
+            "severity": "P0",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-3c9e7697aadc7dc792d81d1f831e8d9f",
+            "classification": "introduced",
+            "findingId": "finding-3c9e7697aadc7dc792d81d1f831e8d9f",
+            "firstSeenThisRound": false,
+            "severity": "P1",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-b89f82c95f673fddd7e8945d7c10afd9",
+            "classification": "introduced",
+            "findingId": "finding-b89f82c95f673fddd7e8945d7c10afd9",
+            "firstSeenThisRound": false,
+            "severity": "P1",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-6acf7521e93730a680f66dad083818af",
+            "classification": "introduced",
+            "findingId": "finding-6acf7521e93730a680f66dad083818af",
+            "firstSeenThisRound": false,
+            "severity": "P1",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-f1eb596cd76a38e421dfc8195c11c371",
+            "classification": "introduced",
+            "findingId": "finding-f1eb596cd76a38e421dfc8195c11c371",
+            "firstSeenThisRound": false,
+            "severity": "P1",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-fadfd735dce642f3fa2b6bcb0e03defe",
+            "classification": "introduced",
+            "findingId": "finding-fadfd735dce642f3fa2b6bcb0e03defe",
+            "firstSeenThisRound": false,
+            "severity": "P1",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-cb3d8591ec065b6883bbf7e24be34668",
+            "classification": "introduced",
+            "findingId": "finding-cb3d8591ec065b6883bbf7e24be34668",
+            "firstSeenThisRound": false,
+            "severity": "P1",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-9fa6186352f18dfe6269baa691d59765",
+            "classification": "introduced",
+            "findingId": "finding-9fa6186352f18dfe6269baa691d59765",
+            "firstSeenThisRound": false,
+            "severity": "P1",
+            "status": "fixed"
+          },
+          {
+            "chainRoot": "finding-b1c5cb287ae47b3772e45fc93ddfebc9",
+            "classification": "introduced",
+            "findingId": "finding-b1c5cb287ae47b3772e45fc93ddfebc9",
+            "firstSeenThisRound": false,
+            "severity": "P2",
+            "status": "fixed"
+          }
+        ],
+        "reviewKind": "plan"
+      },
+      "forced": false,
+      "hash_epoch": 0,
+      "head_sha": "791a7e4c3934fd3495dd0cf2e5bbf7287603d568",
+      "head_sha_observed": true,
+      "kind": "plan",
+      "model": "gpt-5.6-sol",
+      "outcome": "verdict",
+      "output_bytes": 83,
+      "output_sha256": "40d2d19134681e086a006dfc0c8bb45ef809e3140d67088c1eab2d9a33648691",
+      "reservation_id": "0423d730e7cf4f8b9d4743b2ab8ad99c",
+      "round_consumed": true,
+      "scope": "plan",
+      "superseded_by": null,
+      "task": null,
+      "timestamp": "2026-08-28T22:07:56.220784Z",
+      "verdict": "SHIP"
+    }
+  ],
+  "review_hash_epoch": {
+    "plan": 1,
+    "plan#completion": 0
+  },
+  "review_pending_rounds": {},
+  "review_reservations": {},
+  "review_transport_failures": {
+    "plan": 0
+  },
   "spec_path": ".flow/specs/fn-209-no-plan-work-route-tool-permission-audit.md",
   "status": "open",
   "title": "No-plan work route + tool-permission audit",
@@ -20,5 +357,5 @@
     "mergeBaseTracker": null,
     "url": null
   },
-  "updated_at": "2026-08-28T20:55:22.779438Z"
+  "updated_at": "2026-08-28T22:07:56.224617Z"
 }

--- a/.flow/specs/fn-209-no-plan-work-route-tool-permission-audit.md
+++ b/.flow/specs/fn-209-no-plan-work-route-tool-permission-audit.md
@@ -10,7 +10,7 @@ A second, related defect surfaced during design: the worker agent (and two other
 ## Architecture & Data Models
 <!-- Architecture: 40% [user], 60% [paraphrase] -->
 
-- **Work-level, not a pipeline knob.** The route lives in the work skill's spec-mode entry: a zero-task spec triggers an interactive fork (plan first vs work directly). No `pipeline.plan` config key; pilot and land are unchanged and keep routing zero tasks to plan. [user]
+- **Work-level, not a pipeline knob.** The route lives in the work skill's spec-mode entry: a zero-task spec triggers an interactive fork (plan first vs work directly). No `pipeline.plan` config key; land is untouched, and pilot's default classification keeps routing zero tasks to plan — only an explicit `--no-plan` on the pilot invocation adds a first-match row classifying the zero-task spec to the work dispatch that carries the flag. [user]
 - **One implicit task, never zero-task execution.** Once the user has chosen the direct route (ask answer, flag, or natural language), the path mints a single MINIMAL task from the spec — essentially "implement this spec" — with no further asking or confirmation. The task never emulates plan-full by copying a plan into the task body; the task artifact exists for the plumbing that needs it: receipts, evidence, review dispatch, done. The single-task completion-review policy skip composes unchanged. [user]
 - **Harness-owned parallelism.** Plan-full behavior is unchanged: the plan's task decomposition and wave scheduling fix the parallelism shape up front, as today. In the plan-less fork that decision moves to execution time: the dispatch prose licenses broad judicious subagent use (implementation, research, scouting) and names no shape. [user]
 - **Progressive disclosure.** The no-plan branch's machinery lives in a gated reference file loaded only when the fork fires (the established sentinel-gate pattern); plan-full runs read nothing new. [user]
@@ -20,23 +20,29 @@ A second, related defect surfaced during design: the worker agent (and two other
 ## Edge Cases & Constraints
 <!-- Edge Cases: 30% [user], 70% [inferred] -->
 
-- Autonomous contexts never see the ask: Ralph-gated work keeps current behavior, and pilot's own classification is unchanged (zero tasks routes to plan). An explicit `--no-plan` or natural-language instruction on the pilot invocation passes through to the work dispatch as the direct route — a one-line pass-through; pilot never decides no-plan on its own. [user]
+- Autonomous contexts never see the ask: a zero-task spec under Ralph/autonomous markers WITHOUT an explicit no-plan instruction stops with a typed report ("spec has no tasks — run /flow-next:plan") — never the ask, never the silent fall-through. Pilot's default classification is unchanged (zero tasks routes to plan); an explicit `--no-plan` flag on the pilot invocation classifies the zero-task spec to the work dispatch carrying the flag (a first-match row ahead of the default — otherwise the default row would consume the case and the flag could never reach work); pilot never decides no-plan on its own, and takes the flag form only (its parser has no natural-language path). [user + gap resolution]
+- The plan-first answer stops the work run with a one-line pointer to /flow-next:plan; work never invokes plan itself and never chains into it. [gap resolution]
+- Every subagent the judicious-dispatch prose licenses is awaited and reconciled before staging and verification — no live writer exists when the worker stages and commits. [gap resolution]
+- The fork applies to the spec-id entry shape only: spec-file and idea-text starts already mint a single task unconditionally (the documented Small-task variant) and are direct-by-construction — no ask is added there. [gap resolution]
+- `--no-plan` on a spec that already has tasks is ignored with a one-line notice and the planned tasks run; re-invoking after the implicit task exists resolves as the normal resume path (task count is 1), so a second mint is unreachable by construction. [gap resolution]
+- Judicious subagent use never changes commit ownership: the worker remains the only committer, `git add -A` and the single-commit convention stand, and concurrent edits to one file are the worker's to serialize (prefer handing subagents disjoint surfaces). [gap resolution]
+- The host-deferred review contract stays; its stated rationale moves from "worker cannot dispatch Task" (false after R1) to verdict independence — the agent that wrote the code never dispatches or issues its own review verdict. [gap resolution]
 - Subagent nesting is host-dependent (Claude Code enforces a depth limit; other hosts vary): the judicious-subagent prose carries the standard portable-host degradation clause — a host without nested dispatch degrades to serial, never errors. No capability probing beyond that; harnesses improve on their own. [user]
 - A spec with nothing a worker could act on refuses the direct route and hands back to the user with a pointer to plan/interview rather than minting an empty task — one line in the prose, no new ready state, deliberately not overengineered. [user]
 - The legacy zero-task fall-through (a completion review over an empty diff) becomes unreachable via R2's fork; reviewers are unchanged throughout — they judge a task's diff against the spec regardless of how the task was minted. [user]
 
 ## Acceptance Criteria
 
-Standing criteria in `.flow/criteria.md` (G-IDs) apply and are not restated. Process requirements (mirror regen twice, full gate green, docs-site changelog) ride along per the project instruction file and are not counted as R-IDs.
+Standing criteria in `.flow/criteria.md` (G-IDs) apply and are not restated. Process requirements (mirror regen twice, full gate green) ride along per the project instruction file and are not counted as R-IDs. The flow-next.dev changelog entry is an explicit post-merge hold outside this repository: the finalization task flags it in its done summary and the maintainer stages it there — it is deliberately not a task here.
 
 - **R1:** The tool-permission audit lands as one pass: worker, pr-comment-resolver, and plan-sync stop denying Task (plan-sync keeps Write and Bash); read-only agents keep their full denial with a one-line inline rationale; the docs describing agent tool restrictions reflect the corrected understanding (Task is subagent dispatch, renamed Agent in Claude Code v2.1.63, not a planning tool); the strategy skill's Write-only allowlist gets a verdict in passing (add Edit or record it as deliberate); a short parity check confirms Cursor and Grok honor the post-audit permission model. Errors: no error surface beyond host-side nesting depth limits (degradation documented in the dispatch prose). [user]
-- **R2:** `/flow-next:work <spec-id>` on a spec whose task count is zero forks explicitly instead of falling through: never-planned is distinguished from all-tasks-done, and an interactive ask offers plan-first vs work-directly with each option's consequence explained. Errors: the current fall-through (a completion review dispatched over an empty zero-task diff, or a green zero-task run) becomes unreachable; reviewers themselves are unchanged — they always judge a task's diff against the spec. [user]
+- **R2:** `/flow-next:work <spec-id>` on a spec whose task count is zero forks explicitly instead of falling through: never-planned is distinguished from all-tasks-done, and an interactive ask offers plan-first vs work-directly with each option's consequence explained. Errors: the current fall-through (a completion review dispatched over an empty zero-task diff, or a green zero-task run) becomes unreachable; under autonomous markers with no explicit no-plan instruction the run stops with a typed "spec has no tasks" report instead of asking; reviewers themselves are unchanged — they always judge a task's diff against the spec. [user]
 - **R3:** The ask's recommendation is agent-judged per spec from complexity and blast radius (spec size, independent surfaces, riskiness of touched areas), stated with its reason; no static default. Errors: judgment inputs missing (unreadable spec) falls back to recommending plan-first with that stated reason. [user]
-- **R4:** A `--no-plan`-style flag and natural-language intent in the invocation ("work fn-12 no plan", "skip planning") pre-answer the fork so the ask never fires when intent is stated. Errors: contradictory signals (flag says direct, prose says plan) ask instead of guessing. Pilot forwards an explicit no-plan instruction to its work dispatch unchanged (one-line pass-through; pilot's default classification stays plan). [user]
-- **R5:** Once the direct route is chosen, the path mints exactly one MINIMAL implicit task ("implement this spec", not an emulated plan) without further confirmation, then runs the standard work pipeline; receipts, review, done evidence, and the single-task completion-review policy skip compose unchanged. Errors: a spec with no usable acceptance content refuses with a pointer to plan/interview. [user]
-- **R6:** The plan-less dispatch prose grants broad judicious subagent use — parallel implementation of independent surfaces, background research, scouting — with the shape chosen by the harness at execution time, plus the portable-host degradation clause. Errors: none beyond R1's documented degradation. [user]
+- **R4:** A `--no-plan`-style flag and natural-language intent in the invocation ("work fn-12 no plan", "skip planning") pre-answer the fork so the ask never fires when intent is stated. Errors: contradictory signals (flag says direct, prose says plan) ask instead of guessing; the flag on a spec that already has tasks is ignored with a one-line notice. Pilot forwards an explicit `--no-plan` flag to its work dispatch: a new first-match classification row (zero tasks AND the flag present -> work, dispatched with the flag) sits ahead of the default `zero tasks -> plan` row, which is otherwise unchanged — without the flag nothing about pilot moves. [user]
+- **R5:** Once the direct route is chosen, the path mints exactly one MINIMAL implicit task ("implement this spec", not an emulated plan) without further confirmation, then runs the standard work pipeline; the minted task's `satisfies` lists ALL spec R-IDs (so the 3g single-task policy skip and the make-pr coverage table stay correct) and carries no `Touches:` line (a whole-spec task genuinely cannot name its paths); receipts, review, done evidence, and the single-task completion-review policy skip compose unchanged. Errors: a spec with no usable acceptance content refuses with a pointer to plan/interview; a second mint is unreachable (task count 1 resolves as resume). [user]
+- **R6:** The plan-less dispatch prose grants broad judicious subagent use — parallel implementation of independent surfaces, background research, scouting — with the shape chosen by the harness at execution time, plus the portable-host degradation clause and a join barrier: every dispatched subagent is awaited and reconciled before staging, verification, and commit. Errors: none beyond R1's documented degradation. [user]
 - **R7:** The no-plan branch's machinery lives behind a gated reference loaded only when the fork fires; a plan-full run's loaded prose is unchanged. In the same pass, evaluate — defensively, no forced moves — whether existing plan-full-only machinery can also lift behind gates so neither fork always loads the other's paths. Errors: none. [user]
-- **R8:** `flowctl next`'s zero-task-spec treatment is reconciled with the route: either it surfaces the state or its skip is documented as deliberate where the command is defined. Errors: none. [inferred]
+- **R8:** `flowctl next`'s zero-task-spec treatment is reconciled with the route: either it surfaces the state or its skip is documented as deliberate where the command is defined (the silent fall-through is code-confirmed: a zero-task spec builds empty task maps and skips the completion-review branch). Errors: none. [paraphrase]
 - **R9:** The routing surfaces learn the route: a new variant in the pipeline-variations doc, the guide router can recommend it, capture's Recommended-next judgment may name it for near-zero-risk fully-known specs, and the interview write-back next-step hint includes it. Errors: none. [user]
 - **R10:** work-rolling refuses a no-plan invocation with a stated reason (a single implicit task degenerates the rolling frontier) and redirects to plain work. Errors: this IS the refusal criterion. [user]
 
@@ -49,12 +55,42 @@ Standing criteria in `.flow/criteria.md` (G-IDs) apply and are not restated. Pro
 - Plan-review is not re-homed: the direct route skips the plan stage and its automatic plan-review; impl-review and completion review are unchanged, and the user can still run plan-review on the spec manually (it works on a task-less spec). [user]
 - No second worker agent definition. [paraphrase]
 
+## Quick commands
+
+```bash
+# Focused suites for the touched surfaces (full gate runs once at the end):
+cd plugins/flow-next/tests && python3 -m unittest test_cursor_agent_frontmatter test_opencode_agent_frontmatter -q   # agent frontmatter (task .1)
+cd plugins/flow-next/tests && python3 -m unittest test_next_zero_task -q   # flowctl next (task .4 creates this module)
+./scripts/sync-codex.sh && ./scripts/sync-codex.sh   # mirror idempotency (finalization)
+```
+
+## Strategy Alignment
+
+Active tracks served by this plan:
+- **Cross-platform parity** — the tool-permission audit lands identically on Claude/Droid (frontmatter), Codex (sandbox, unchanged), OpenCode (generated permission map), and adds the Cursor/Grok parity check R1 names.
+
+## Early proof point
+
+Task fn-209-no-plan-work-route-tool-permission-audit.2 validates the core approach (the zero-task fork asks, the flag/NL pre-answers, and one minimal implicit task runs the standard pipeline end to end). If it fails, re-evaluate the fork-in-Phase-1 placement before continuing with the routing-surface tasks.
+
 ## Decision Context
 
-The maintainer chose the work-level fork over a pipeline config knob ("variant 1 work-level") after seeing both laid out — the ask-plus-flag shape keeps autonomous loops planning while giving interactive users the direct route. The Task-ban removal rests on verified archaeology: the ban shipped in the worker's first commit with no rationale in commit, PR, or docs; the maintainer believed Task related to Claude Code's native planning feature; official Claude Code docs confirm Task is the subagent-dispatch tool (renamed Agent in v2.1.63, alias kept) and unrelated to plan mode or the TaskCreate checklist tools. The skill-layer allowlists were audited and found correct (skills that dispatch scouts all include Task), which narrows the fix to the three writing agents. A zero-task execution model was rejected — flow-next's receipts and reviews are keyed to tasks. The read-only agents keep their denial by explicit decision (confirmed at read-back, revising the initial "remove task everywhere"): a read-only agent that can spawn a writing subagent has an escape hatch out of read-only — the same reason Claude Code's own Explore agent excludes dispatch. The implicit task is deliberately minimal: plan-less mode must not emulate plan-full by writing a plan into the task body; the agent works from the spec, and the task artifact serves the plumbing.
+The maintainer chose the work-level fork over a pipeline config knob ("variant 1 work-level") after seeing both laid out — the ask-plus-flag shape keeps autonomous loops planning while giving interactive users the direct route. The Task-ban removal rests on verified archaeology: the ban shipped in the worker's first commit with no rationale in commit, PR, or docs; the maintainer believed Task related to Claude Code's native planning feature; official Claude Code docs confirm Task is the subagent-dispatch tool (renamed Agent in v2.1.63, alias kept) and unrelated to plan mode or the TaskCreate checklist tools. The skill-layer allowlists were audited and found correct (skills that dispatch scouts all include Task), which narrows the fix to the three writing agents. A zero-task execution model was rejected — flow-next's receipts and reviews are keyed to tasks. The read-only agents keep their denial by explicit decision (confirmed at read-back, revising the initial "remove task everywhere"): a read-only agent that can spawn a writing subagent has an escape hatch out of read-only — the same reason Claude Code's own Explore agent excludes dispatch. The implicit task is deliberately minimal: plan-less mode must not emulate plan-full by writing a plan into the task body; the agent works from the spec, and the task artifact serves the plumbing. Planning-stage resolutions: the host-deferred review contract is kept and re-justified on verdict independence (the writer never issues its own review verdict) — the old "worker cannot dispatch Task" rationale in the work skill's prose becomes false with R1 and is corrected in the same pass. No new subagent-usage prose is added for plan-full workers — judgment governs there (deliberate; the bitter-lesson stance). work-rolling's refusal is a pre-check in its own skill file because it inherits canonical Phase 1 by pointer and would otherwise silently inherit the fork. Sequencing: fn-208 (open, in review) edits the worker agent, pilot, and interview surfaces — implementation of this spec starts from fn-208's landed state; adjacency only, no dependency edge.
 
 ## Requirement coverage
 
-| R-ID | Task |
-|------|------|
-| R1–R10 | fn-N.M (TBD — populate via /flow-next:plan) |
+| Req | Description | Task(s) | Gap justification |
+|-----|-------------|---------|-------------------|
+| R1 | Tool-permission audit pass | fn-209.1 | — |
+| R2 | Zero-task fork in work | fn-209.2 | — |
+| R3 | Agent-judged recommendation | fn-209.2 | — |
+| R4 | Flag/NL pre-answer + pilot pass-through | fn-209.2, fn-209.3 | — |
+| R5 | Minimal implicit task mint | fn-209.2 | — |
+| R6 | Judicious-subagent dispatch prose | fn-209.2 | — |
+| R7 | Gated reference / progressive disclosure | fn-209.2 | — |
+| R8 | flowctl next reconciliation | fn-209.4 | — |
+| R9 | Routing surfaces learn the route | fn-209.5 | — |
+| R10 | work-rolling refusal | fn-209.5 | — |
+
+(Task ids abbreviated: fn-209.N = fn-209-no-plan-work-route-tool-permission-audit.N. Task .6 is finalization — mirror regen, manifest, changelogs, full gate — process work with no counted R-ID.)
+

--- a/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.1.json
+++ b/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-08-28T21:56:26.768191Z",
+  "depends_on": [],
+  "id": "fn-209-no-plan-work-route-tool-permission-audit.1",
+  "priority": null,
+  "spec": "fn-209-no-plan-work-route-tool-permission-audit",
+  "spec_path": ".flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.1.md",
+  "status": "todo",
+  "title": "Tool-permission audit: remove writer Task denials, rationale on read-only, doc + parity pass",
+  "updated_at": "2026-08-28T21:56:26.768191Z"
+}

--- a/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.1.md
+++ b/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.1.md
@@ -1,0 +1,48 @@
+---
+satisfies: [R1]
+---
+# fn-209-no-plan-work-route-tool-permission-audit.1 Tool-permission audit: remove writer Task denials, rationale on read-only, doc + parity pass
+
+## Description
+Land the R1 audit pass across agent frontmatter, the docs that describe it, the strategy-skill allowlist verdict, and the Cursor/Grok parity check. Split this way because it is the only task touching agents/** and the permission docs.
+
+**Size:** M
+**Files:** `plugins/flow-next/agents/worker.md`, `plugins/flow-next/agents/pr-comment-resolver.md`, `plugins/flow-next/agents/plan-sync.md`, all read-only `plugins/flow-next/agents/*.md`, `CLAUDE.md`, `plugins/flow-next/docs/platforms.md`, `plugins/flow-next/skills/flow-next-strategy/SKILL.md`
+**Touches:** [plugins/flow-next/agents/**, CLAUDE.md, plugins/flow-next/docs/platforms.md, plugins/flow-next/skills/flow-next-strategy/SKILL.md]
+
+### Approach
+- `worker.md:5` and `pr-comment-resolver.md:5`: remove the whole `disallowedTools: Task` line (Task is the only token). `plan-sync.md:4`: `Task, Write, Bash` -> `Write, Bash`.
+- Every read-only agent keeps `disallowedTools: Edit, Write, Task` and gains a one-line inline rationale comment (NEW convention - no existing example; keep it to one short line, e.g. `# read-only: Task would be a write escape hatch via a spawned writing subagent`). Verify the comment survives sync-codex (frontmatter comments are swallowed by the mirror's case parser - confirm, do not assume) and the OpenCode generator's closed key parsing.
+- `CLAUDE.md` (Agent permissions bullet + checklist item) and `platforms.md` deny-list prose: distinguish read-only agents (deny all three, with the escape-hatch rationale) from writing agents (deny Edit/Write subsets only), and add one line: Task is subagent dispatch (renamed Agent in Claude Code v2.1.63), not a planning tool.
+- Strategy skill verdict: `flow-next-strategy/SKILL.md:5` lacks Edit while pilot/land/map carry it. Read its maintain path; either add Edit or record Write-only as deliberate in a one-line comment beside the allowlist.
+- Cursor/Grok parity check (short, evidence-based): confirm Cursor honors `disallowedTools`/`readonly` on canonical files and Grok's Claude-plugin compat leaves the post-audit model intact; record findings (dated) in `platforms.md` only if behavior differs.
+- Do NOT touch `phases.md` or `references/host-deferred-review.md` here - the host-deferred rationale fix belongs to task 2 (file ownership).
+
+### Investigation targets
+**Required** (read before coding):
+- `plugins/flow-next/agents/plan-sync.md:1-8` - frontmatter shape to edit
+- `scripts/sync-codex.sh:1875-1890` - frontmatter case parser (how unknown/comment lines flow)
+- `plugins/flow-next/scripts/lib/opencode_generate.py:47-100` - token map + closed allowlist the comment must not break
+- `plugins/flow-next/tests/test_cursor_agent_frontmatter.py:78-135` - Edit+Write invariants that must stay green
+
+**Optional:**
+- `plugins/flow-next/tests/test_opencode_agent_frontmatter.py` - dynamic reads, run to confirm
+
+### Acceptance
+- [ ] worker + pr-comment-resolver carry no Task denial; plan-sync denies exactly Write, Bash
+- [ ] every read-only agent still denies Edit, Write, Task and carries the one-line rationale
+- [ ] CLAUDE.md + platforms.md describe the post-audit model incl. the v2.1.63 rename fact
+- [ ] strategy allowlist has a recorded verdict (Edit added, or deliberate Write-only noted)
+- [ ] Cursor/Grok parity check done with dated evidence; platforms.md updated only on a real difference
+- [ ] `python3 -m unittest test_cursor_agent_frontmatter test_opencode_agent_frontmatter -q` green
+
+## Acceptance
+- [ ] TBD
+
+## Done summary
+TBD
+
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.2.json
+++ b/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.2.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-08-28T21:56:26.768253Z",
+  "depends_on": [],
+  "id": "fn-209-no-plan-work-route-tool-permission-audit.2",
+  "priority": null,
+  "spec": "fn-209-no-plan-work-route-tool-permission-audit",
+  "spec_path": ".flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.2.md",
+  "status": "todo",
+  "title": "work zero-task fork: ask + flag/NL, minimal implicit task, judicious-subagent prose, gated reference",
+  "updated_at": "2026-08-28T22:06:04.963700Z"
+}

--- a/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.2.md
+++ b/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.2.md
@@ -1,0 +1,51 @@
+---
+satisfies: [R2, R3, R4, R5, R6, R7]
+---
+# fn-209-no-plan-work-route-tool-permission-audit.2 work zero-task fork: ask + flag/NL, minimal implicit task, judicious-subagent prose, gated reference
+
+## Description
+The core route (R2-R7): the zero-task fork in work's spec mode, the pre-answer flag/NL, the minimal implicit-task mint, the judicious-subagent dispatch prose, all behind a new gated reference - plus the host-deferred rationale correction that R1 makes necessary (this task owns the work skill's files).
+
+**Size:** L-leaning-M (cohesive; do not split - all edits land in the work skill's own files)
+**Files:** `plugins/flow-next/skills/flow-next-work/phases.md`, `plugins/flow-next/skills/flow-next-work/SKILL.md`, `plugins/flow-next/skills/flow-next-work/references/no-plan-route.md` (new), `plugins/flow-next/skills/flow-next-work/references/host-deferred-review.md`
+**Touches:** [plugins/flow-next/skills/flow-next-work/**]
+
+### Approach
+- Fork site: `phases.md:46-50` (SPEC_MODE, after `ready --spec` returns empty). Distinguish zero-tasks-ever from all-done BEFORE the Phase 3 fall-through; route the legacy fall-through out of existence (R2). Spec-file/idea-text entry shapes (`phases.md:51-70`) stay untouched - direct-by-construction.
+- Gate the whole branch behind a sentinel + new `references/no-plan-route.md` (copy the sentinel phrasing at `phases.md:450-453` and the reference-header convention of `references/host-deferred-review.md:1-6`). Plan-full runs read nothing new (R7). In the same pass evaluate - defensively, no forced moves - whether existing plan-full-only machinery can also lift behind gates.
+- The reference owns: the ask (plan-first vs work-directly; copy the lettered-options + natural-language-fallback phrasing of `references/setup-questions.md:12-42`; recommendation is agent-judged per spec from size/independent-surfaces/blast-radius with the reason stated, R3; consequence-explained options; fallback to plan-first when the spec is unreadable), the autonomous typed refusal ("spec has no tasks - run /flow-next:plan" under any autonomy marker without an explicit no-plan instruction; scan the marker FAMILY - FLOW_RALPH, FLOW_AUTONOMOUS, REVIEW_RECEIPT_PATH, mode:autonomous - per the memory lesson), the plan-first semantics (that answer STOPS the run with a one-line pointer to /flow-next:plan - work never invokes plan itself), and the mint.
+- Flag/NL parsing joins `SKILL.md:94-117` (`--no-plan` + phrases like "no plan"/"skip planning"); contradictory signals ask; the flag on a spec WITH tasks is ignored with a one-line notice (R4).
+- Mint: reuse the exact call shape at `phases.md:51-70` - `task create --spec <id> --title "Implement <spec title>"` - MINIMAL body (never an emulated plan), `--satisfies` listing ALL spec R-IDs (keeps 3g policy skip + make-pr coverage correct), no Touches line. Re-run resolves as resume (task count 1) - state it in the reference (R5).
+- Judicious-subagent prose (R6, in the reference, part of the worker dispatch for the minted task): broad license - parallel implementation of independent surfaces, background research, scouting - shape chosen by the harness; portable-host degradation clause (no nested dispatch -> serial, never errors; no capability probing); commit ownership unchanged (worker is the only committer, single-commit + `git add -A` stand; hand subagents disjoint surfaces or serialize), and a join barrier: every dispatched subagent is awaited and reconciled before staging, verification, and commit - no live writer at `git add -A` time.
+- host-deferred correction: `phases.md:227` and `references/host-deferred-review.md:15` currently justify the contract with "worker cannot dispatch Task" - false after task 1. Re-justify on verdict independence: the agent that wrote the code never dispatches or issues its own review verdict. Contract mechanics unchanged.
+- Mirror note: canonical 3c is NOT touched. Do NOT run `./scripts/sync-codex.sh` in this task - the worker's `git add -A` would stage a partial mirror regen; the committed regen and its guards belong wholly to task 6.
+
+### Investigation targets
+**Required** (read before coding):
+- `plugins/flow-next/skills/flow-next-work/phases.md:40-110` - Phase 1 entry shapes + zero-task fall-through
+- `plugins/flow-next/skills/flow-next-work/phases.md:379-476` - 3g gate incl. single-task policy skip + sentinel pattern
+- `plugins/flow-next/skills/flow-next-work/SKILL.md:94-117` - option parsing block
+- `plugins/flow-next/skills/flow-next-work/references/setup-questions.md:12-42` - ask phrasing convention
+- `plugins/flow-next/skills/flow-next-work/references/host-deferred-review.md` - contract whose rationale this task corrects
+
+**Optional:**
+- `plugins/flow-next/skills/flow-next-work/references/spec-id-mint.md` - mint-gate reference shape
+
+### Acceptance
+- [ ] zero-task spec-id run forks: interactive ask (agent-judged rec, consequences explained), autonomous typed refusal, flag/NL pre-answer - legacy fall-through unreachable
+- [ ] direct route mints exactly one minimal task, satisfies = all spec R-IDs, no Touches; re-run resumes, never re-mints
+- [ ] judicious-subagent prose present with portable-host degradation, commit-ownership bound, and the await-before-staging join barrier
+- [ ] no-plan machinery lives in `references/no-plan-route.md` behind a sentinel; plan-full path loads nothing new
+- [ ] host-deferred rationale corrected to verdict independence in both files
+- [ ] no sync-codex run in this task (regen wholly owned by task 6)
+- [ ] one live dogfood run of the no-plan route on a throwaway spec - fork ask, flag pre-answer, and autonomous refusal each exercised once - with the evidence recorded in the done summary
+## Acceptance
+- [ ] TBD
+
+## Done summary
+TBD
+
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.3.json
+++ b/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.3.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-08-28T21:56:26.768297Z",
+  "depends_on": [],
+  "id": "fn-209-no-plan-work-route-tool-permission-audit.3",
+  "priority": null,
+  "spec": "fn-209-no-plan-work-route-tool-permission-audit",
+  "spec_path": ".flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.3.md",
+  "status": "todo",
+  "title": "pilot --no-plan pass-through",
+  "updated_at": "2026-08-28T22:07:28.569556Z"
+}

--- a/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.3.md
+++ b/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.3.md
@@ -1,0 +1,36 @@
+---
+satisfies: [R4]
+---
+# fn-209-no-plan-work-route-tool-permission-audit.3 pilot --no-plan pass-through
+
+## Description
+The pilot half of R4: accept an explicit `--no-plan` on the pilot invocation and forward it to the work dispatch. Default classification stays unchanged (zero tasks -> plan); with the flag, a preceding first-match row classifies the zero-task spec to work so the flag can actually reach the dispatch.
+
+**Size:** S
+**Files:** `plugins/flow-next/skills/flow-next-pilot/SKILL.md`, `plugins/flow-next/skills/flow-next-pilot/workflow.md`
+**Touches:** [plugins/flow-next/skills/flow-next-pilot/**]
+
+### Approach
+- Add a `--no-plan` case to the flag-only Mode Detection parser at `SKILL.md:57-88` (new `PILOT_NO_PLAN` var beside the exports at :87). The parser has NO natural-language path - do not add one; document that pilot takes the flag form only (`set -- $ARGUMENTS` word-splits; never claim verbatim NL passthrough, per the memory lesson).
+- Classification (`workflow.md:345-354`, first-match table): add a row `0 tasks exist AND PILOT_NO_PLAN -> work` immediately BEFORE the default `0 tasks exist -> plan` row - without it the default row consumes the case and the flag never reaches a work dispatch. The default row itself stays byte-unchanged, as does every other row.
+- Append the flag to the work dispatch line at `workflow.md:446` only when set.
+
+### Investigation targets
+**Required:**
+- `plugins/flow-next/skills/flow-next-pilot/SKILL.md:57-88` - parser loop + exports
+- `plugins/flow-next/skills/flow-next-pilot/workflow.md:440-450` - dispatch invocation lines
+
+### Acceptance
+- [ ] `--no-plan` parses into PILOT_NO_PLAN; with it, a zero-task spec classifies to the work dispatch carrying the flag (new first-match row); absent -> classification and dispatch byte-unchanged
+- [ ] both cases exercised in the dogfood/verification evidence; no NL parsing added to pilot
+- [ ] unknown-flag stderr behavior for other args unchanged
+## Acceptance
+- [ ] TBD
+
+## Done summary
+TBD
+
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.4.json
+++ b/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.4.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-08-28T21:56:26.768332Z",
+  "depends_on": [],
+  "id": "fn-209-no-plan-work-route-tool-permission-audit.4",
+  "priority": null,
+  "spec": "fn-209-no-plan-work-route-tool-permission-audit",
+  "spec_path": ".flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.4.md",
+  "status": "todo",
+  "title": "flowctl next: surface the zero-task spec state",
+  "updated_at": "2026-08-28T22:06:05.467288Z"
+}

--- a/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.4.md
+++ b/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.4.md
@@ -1,0 +1,41 @@
+---
+satisfies: [R8]
+---
+# fn-209-no-plan-work-route-tool-permission-audit.4 flowctl next: surface the zero-task spec state
+
+## Description
+Reconcile `cmd_next`'s silent zero-task fall-through (empty task maps skip every branch; spec silently skipped) with the route: surface the state instead of skipping it silently.
+
+**Size:** S-M
+**Files:** `plugins/flow-next/scripts/flowctl.py`, `plugins/flow-next/docs/flowctl.md`, `plugins/flow-next/tests/test_next_zero_task.py` (new)
+**Touches:** [plugins/flow-next/scripts/flowctl.py, plugins/flow-next/docs/flowctl.md, plugins/flow-next/tests/test_next_zero_task.py]
+
+### Approach
+- `flowctl.py` `cmd_next` (~:34134-34333): a non-closed spec with zero tasks currently builds empty maps and falls to the next spec / `status: none`. Decide the surfaced shape against the doc'd contract at `docs/flowctl.md:870-883` (statuses `plan|work|completion_review|none`): emitting `status: plan` with a `needs_tasks`-style reason for the first zero-task spec mirrors pilot's classification and is the recommended resolution; a documented deliberate skip is the acceptable fallback if the surfaced form breaks existing consumers (check pilot + ralph consumers of `next` output first).
+- Regression test: NEW module `plugins/flow-next/tests/test_next_zero_task.py` (no test_next*.py exists today - `discover -p` currently collects 0 tests, which is exactly the false-green the memory bank warns about): zero-task open spec -> asserted surfaced state; plus the existing modules covering cmd_next stay green (locate them via `grep -l "next" tests/*.py` and run them).
+- flowctl.md `### next` doc row update belongs to task 5's doc pass? NO - keep the doc edit HERE (same change, same reviewer): update `docs/flowctl.md:870-883` in this task; task 5 does not touch flowctl.md.
+
+### Investigation targets
+**Required:**
+- `plugins/flow-next/scripts/flowctl.py:34134-34333` - cmd_next body incl. empty-map path
+- `plugins/flow-next/docs/flowctl.md:870-883` - documented next contract
+- callers: grep pilot/ralph skills for `flowctl next` consumption before changing output shape
+
+**Optional:**
+- existing tests: `grep -l cmd_next plugins/flow-next/tests/*.py`
+
+### Acceptance
+- [ ] zero-task open spec is surfaced (recommended: status plan + reason) or the skip is documented as deliberate in code comment + flowctl.md - one of the two, explicitly
+- [ ] regression test covers the zero-task path; existing next tests green
+- [ ] `docs/flowctl.md` next section matches the shipped behavior
+- [ ] `uvx ruff@0.16.0 check .` green
+## Acceptance
+- [ ] TBD
+
+## Done summary
+TBD
+
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.5.json
+++ b/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.5.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-08-28T21:56:26.768365Z",
+  "depends_on": [],
+  "id": "fn-209-no-plan-work-route-tool-permission-audit.5",
+  "priority": null,
+  "spec": "fn-209-no-plan-work-route-tool-permission-audit",
+  "spec_path": ".flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.5.md",
+  "status": "todo",
+  "title": "Routing surfaces + work-rolling refusal + conduct checklists",
+  "updated_at": "2026-08-28T21:56:26.768365Z"
+}

--- a/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.5.md
+++ b/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.5.md
@@ -1,0 +1,48 @@
+---
+satisfies: [R9, R10]
+---
+# fn-209-no-plan-work-route-tool-permission-audit.5 Routing surfaces + work-rolling refusal + conduct checklists
+
+## Description
+Teach the routing surfaces the new route (R9) and add work-rolling's refusal pre-check (R10), plus the conduct-checklist items the repo requires for skill-prose changes.
+
+**Size:** M
+**Files:** `plugins/flow-next/docs/pipeline-variations.md`, `plugins/flow-next/docs/running-lean.md`, `plugins/flow-next/skills/flow-next-guide/SKILL.md`, `plugins/flow-next/skills/flow-next-capture/workflow.md`, `plugins/flow-next/skills/flow-next-interview/SKILL.md`, `plugins/flow-next/skills/flow-next-work-rolling/SKILL.md`, `agent_docs/conduct/{work,work-rolling,guide,capture,interview}.md`, `GLOSSARY.md`
+**Touches:** [plugins/flow-next/docs/pipeline-variations.md, plugins/flow-next/docs/running-lean.md, plugins/flow-next/skills/flow-next-guide/**, plugins/flow-next/skills/flow-next-capture/workflow.md, plugins/flow-next/skills/flow-next-interview/SKILL.md, plugins/flow-next/skills/flow-next-work-rolling/SKILL.md, agent_docs/conduct/**, GLOSSARY.md]
+
+### Approach
+- pipeline-variations.md: new variant row in the table (:31-37) + its own `###` section between "Feature, requirements known" (:50-59) and "Small task" (:61-75), following the Signal -> diagram -> prose shape; cross-link the GLOSSARY "No-plan route" entry (currently an orphan).
+- guide matrix (`flow-next-guide/SKILL.md:41-55`): add the route between rows 51-52 ("ready spec, small bounded surface, work directly - no plan"). Router staleness is a defect per :63.
+- capture (`flow-next-capture/workflow.md:666-674`): the legal-targets CLOSED LIST must explicitly admit the no-plan route for near-zero-risk fully-known specs; keep chart excluded.
+- interview (`flow-next-interview/SKILL.md:446`): extend the "spec without tasks -> /flow-next:plan" hint with the no-plan alternative.
+- running-lean.md `:3`/`:16`: verify the `spec -> plan -> work` framing still reads as the default; add at most a one-line pointer to the variant. No layer-table row (no config key exists).
+- work-rolling (`flow-next-work-rolling/SKILL.md`, BEFORE the :37 "follow canonical in full" line): pre-check refusing `--no-plan`/NL no-plan with the stated reason (single implicit task degenerates the rolling frontier) and a redirect to plain work - style-match the planSync guardrail at :49. Canonical Phase 1 cannot know it runs under rolling; the refusal must live here.
+- conduct checklists (single-checkbox grammar ending "...has broken this"): work.md - zero-task fork/ask/pre-answer/minimal-mint item(s); work-rolling.md - refusal bullet; guide.md - matrix covers the route; capture.md - Recommended-next may name it; interview.md - next-step hint includes it.
+- GLOSSARY "No-plan route" entry: re-verify wording against shipped behavior; add cross-links.
+
+### Investigation targets
+**Required:**
+- `plugins/flow-next/docs/pipeline-variations.md:31-76` - table + section shapes
+- `plugins/flow-next/skills/flow-next-capture/workflow.md:660-680` - closed-list sentence
+- `plugins/flow-next/skills/flow-next-work-rolling/SKILL.md:30-55` - execution contract + guardrail style
+
+**Optional:**
+- `agent_docs/conduct/README.md` - checklist conventions
+
+### Acceptance
+- [ ] pipeline-variations has the sixth variant (table row + section) cross-linked to GLOSSARY
+- [ ] guide matrix, capture legal-target list, interview hint each name the route
+- [ ] work-rolling refuses no-plan with reason + redirect, before delegating to canonical phases
+- [ ] all five conduct checklists carry the new items in house grammar
+- [ ] running-lean framing verified; docs-only edits, no version bump
+
+## Acceptance
+- [ ] TBD
+
+## Done summary
+TBD
+
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.6.json
+++ b/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.6.json
@@ -1,0 +1,20 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-08-28T21:56:26.768399Z",
+  "depends_on": [
+    "fn-209-no-plan-work-route-tool-permission-audit.1",
+    "fn-209-no-plan-work-route-tool-permission-audit.2",
+    "fn-209-no-plan-work-route-tool-permission-audit.3",
+    "fn-209-no-plan-work-route-tool-permission-audit.4",
+    "fn-209-no-plan-work-route-tool-permission-audit.5"
+  ],
+  "id": "fn-209-no-plan-work-route-tool-permission-audit.6",
+  "priority": null,
+  "spec": "fn-209-no-plan-work-route-tool-permission-audit",
+  "spec_path": ".flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.6.md",
+  "status": "todo",
+  "title": "Finalization: mirror regen, manifest, changelogs, What's-new, full gate",
+  "updated_at": "2026-08-28T22:06:05.718687Z"
+}

--- a/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.6.md
+++ b/.flow/tasks/fn-209-no-plan-work-route-tool-permission-audit.6.md
@@ -1,0 +1,38 @@
+# fn-209-no-plan-work-route-tool-permission-audit.6 Finalization: mirror regen, manifest, changelogs, What's-new, full gate
+
+## Description
+Single finalization task (per the folding rule): regenerate the mirrors and manifest that tasks 1-5 deliberately left uncommitted so their Touches stayed disjoint, land the user-facing release notes, and run the full gate.
+
+**Size:** S-M
+**Files:** `plugins/flow-next/codex/**` (regen), `plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json` (regen), `plugins/flow-next/docs/README.md`, `CHANGELOG.md`
+**Touches:** [plugins/flow-next/codex/**, plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json, plugins/flow-next/docs/README.md, CHANGELOG.md]
+
+### Approach
+- `./scripts/sync-codex.sh` TWICE (idempotency; hard-fail guards are load-bearing - fix content or extend a transform, never relax a guard); commit the mirror diff.
+- `python3 scripts/gen_tracker_manifest.py` (flowctl.py changed in task 4).
+- docs README "What's new" entry (bold name - paragraph - Enable - Details links shape).
+- CHANGELOG `## Unreleased` entry, user-outcome-first per agent_docs/releasing.md; the flow-next.dev changelog is an EXPLICIT post-merge hold per the spec's AC preamble - flag it prominently in the done summary (never attempt it from this checkout); the maintainer stages it in the docs-site repo.
+- Verify make-pr's coverage path on a no-plan-shaped spec (single task, satisfies = all R-IDs) renders without the declared-coverage abort - a read-through of `flow-next-make-pr/workflow.md` qualifier clauses plus one dry-run if cheap.
+- Full gate: `python3 scripts/run_tests_parallel.py` + `uvx ruff@0.16.0 check .` - both green before handoff.
+
+### Investigation targets
+**Required:**
+- `scripts/sync-codex.sh` guard output on first run - drives any transform extensions
+- `plugins/flow-next/skills/flow-next-make-pr/workflow.md` - declared-coverage qualifier clauses
+
+### Acceptance
+- [ ] sync-codex run twice, idempotent, guards green, mirror diff committed
+- [ ] tracker manifest regenerated and committed
+- [ ] What's-new + CHANGELOG Unreleased entries staged (no version bump); docs-site changelog flagged in done summary
+- [ ] make-pr no-plan coverage path verified (no abort)
+- [ ] full suite + ruff green
+## Acceptance
+- [ ] TBD
+
+## Done summary
+TBD
+
+## Evidence
+- Commits:
+- Tests:
+- PRs:


### PR DESCRIPTION
## Summary

Task breakdown + plan-review for fn-209 (captured in #380). Spec body gains the planning-pass resolutions; 6 tasks land — 5 parallel candidates with disjoint `Touches:` declarations and one finalization task owning the mirror regen, manifest, and changelog so the wave stays parallel.

## What changed

- `.flow/specs/fn-209-…` — revised body: pilot pass-through corrected to a first-match classifier row, autonomous typed refusal, plan-first stop semantics, minimal implicit-task contract (`satisfies` = all R-IDs, no Touches), subagent join barrier, host-deferred review re-justified on verdict independence, docs-site changelog reclassified as an explicit post-merge hold, fn-208 recorded as a spec dependency
- `.flow/tasks/fn-209-….1–6` — the six tasks (audit pass / work fork / pilot pass-through / flowctl next / routing surfaces + work-rolling refusal / finalization)

## Verification

- `flowctl validate --spec fn-209-…` — valid, 6 tasks
- Plan review: codex backend, `gpt-5.6-sol` at high — two NEEDS_WORK rounds (9 findings: 1 P0, 7 P1, 1 P2 — all fixed), SHIP on round 3; receipt-continuous session

## Version note

No version bump — .flow planning artifacts only.

https://claude.ai/code/session_0197ehG7tJuDZpbrn7JsTAyg