### PR TITLE
Comment-as-alibi finding class in code review prompts

### DIFF
--- a/.flow/specs/fn-210-comment-as-alibi-finding-class-in-code.json
+++ b/.flow/specs/fn-210-comment-as-alibi-finding-class-in-code.json
@@ -1,0 +1,24 @@
+{
+  "branch_name": "fn-210-comment-as-alibi-finding-class-in-code",
+  "created_at": "2026-08-29T10:13:08.909434Z",
+  "depends_on_epics": [],
+  "id": "fn-210-comment-as-alibi-finding-class-in-code",
+  "next_task": 1,
+  "plan_review_status": "unknown",
+  "plan_reviewed_at": null,
+  "spec_path": ".flow/specs/fn-210-comment-as-alibi-finding-class-in-code.md",
+  "status": "open",
+  "title": "Comment-as-alibi finding class in code review prompts",
+  "tracker": {
+    "baseHashFlow": null,
+    "baseHashTracker": null,
+    "depRelations": [],
+    "id": null,
+    "identifier": null,
+    "lastSyncedAt": null,
+    "mergeBaseFlow": null,
+    "mergeBaseTracker": null,
+    "url": null
+  },
+  "updated_at": "2026-08-29T10:13:08.911810Z"
+}

--- a/.flow/specs/fn-210-comment-as-alibi-finding-class-in-code.md
+++ b/.flow/specs/fn-210-comment-as-alibi-finding-class-in-code.md
@@ -1,0 +1,40 @@
+# Comment-as-alibi finding class in code review prompts
+
+## Goal & Context
+
+The worker's authoring rule "Comments are not alibis" (agents/worker.md, shipped 4.8.0) forbids comments that exist to justify a workaround: fix the code, or encode the constraint as an assert/test/lint rule, then delete the prose. Nothing on the review side checks it — the impl-review and standalone-review prompts never name the pattern, so a workaround wearing a paragraph-long justification sails through review as "well documented." The authoring agent is the wrong enforcement point for its own comments; the fresh-context reviewer is the right one.
+
+This spec adds the reviewer half: a named **comment-as-alibi** finding class in the impl-review and standalone-review prompts. The reviewer treats a justifying comment as a flag on the underlying code — the workaround is the finding, the comment is the signal. The keep-list is shared verbatim with the worker rule so author and reviewer never disagree about which comments are licensed.
+
+## Edge Cases & Constraints
+
+- The finding's severity is judged from the workaround, not the prose. A fix that rewrites or deletes the comment while keeping the workaround does not resolve the finding.
+- Licensed comments are never flagged: license headers, external-constraint notes, lint suppressions with reasons, public API contracts, issue links (the worker rule's keep-list, verbatim).
+- Prompt constants and their on-disk templates stay byte-identical (fn-112.3); this is a deliberate prompt change, so hash pins and rendered fixtures update in the same commit with the rationale in the message.
+
+## Acceptance Criteria
+
+- **R1:** The impl-review prompt (constant + template) names comment-as-alibi as a finding class: a comment that exists to justify a workaround or narrate around a hack flags the underlying code for review; severity is judged from the workaround, not the comment; rewriting or deleting the comment alone does not resolve the finding. The keep-list (license headers, external-constraint notes, lint suppressions with reasons, public API contracts, issue links) is stated so licensed comments are never flagged. No error surface beyond the review verdict itself.
+- **R2:** The standalone-review prompt (constant + template) carries the same finding class with the identical keep-list.
+- **R3:** Prompt-integrity guards stay green through the change: constant/template byte-parity holds, `test_prompt_text_pinned.py` pins and the rendered-prompt fixtures are updated in the same commit, and the codex mirror is regenerated idempotently.
+- **R4:** The repo `CHANGELOG.md` gains an `## Unreleased` entry describing the finding class user-outcome-first.
+
+## Boundaries
+
+- No new skill, agent, or sticky comment-review overlay.
+- No `.flow/criteria.md` G-ID.
+- No change to the worker's authoring rule (already shipped) beyond keeping the keep-list identical.
+- Plan-review and completion-review prompts untouched — they judge plans and coverage, not diff hunks.
+- No version bump in this change (batched release rule).
+
+## Decision Context
+
+- Enforcement lives in the review rubric, not a dedicated skill: a separate always-on comment pass costs context on every run, and the authoring agent defending its own comments is the failure mode this closes.
+- The keep-list is copied verbatim from the worker rule rather than referenced, because the prompts are self-contained payloads sent to external reviewer models that cannot follow a repo pointer.
+- Scope is the two diff-reviewing prompts only; widening to completion review was considered and rejected (it verifies requirement coverage, not code quality).
+
+## Quick commands
+
+```bash
+cd plugins/flow-next/tests && python3 -m unittest test_prompt_text_pinned test_review_prompt_template_parity -q
+```

--- a/.flow/tasks/fn-210-comment-as-alibi-finding-class-in-code.1.json
+++ b/.flow/tasks/fn-210-comment-as-alibi-finding-class-in-code.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-08-29T10:13:23.310975Z",
+  "depends_on": [],
+  "id": "fn-210-comment-as-alibi-finding-class-in-code.1",
+  "priority": null,
+  "spec": "fn-210-comment-as-alibi-finding-class-in-code",
+  "spec_path": ".flow/tasks/fn-210-comment-as-alibi-finding-class-in-code.1.md",
+  "status": "todo",
+  "title": "Implement Comment-as-alibi finding class in code review prompts",
+  "updated_at": "2026-08-29T10:13:23.310975Z"
+}

--- a/.flow/tasks/fn-210-comment-as-alibi-finding-class-in-code.1.md
+++ b/.flow/tasks/fn-210-comment-as-alibi-finding-class-in-code.1.md
@@ -10,9 +10,8 @@ TBD
 Every R-ID in the parent spec's ## Acceptance Criteria is satisfied; judge this task against the spec's criteria directly.
 
 ## Done summary
-TBD
-
+Added the comment-as-alibi finding class to the impl-review and standalone-review prompts (constant + template, byte-identical): a comment justifying a workaround flags the underlying code, severity is judged from the workaround, and rewriting or deleting the comment alone does not resolve the finding. Keep-list copied verbatim from the worker authoring rule. Hash pins and rendered fixtures updated in the same commit; codex mirror regenerated idempotently; CHANGELOG Unreleased entry added. Implemented via the no-plan route with a grok-4.6 bridge worker; in-host review verdict SHIP; full suite (4545) + ruff green.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: 27fc137e
+- Tests: cd plugins/flow-next/tests && python3 -m unittest test_prompt_text_pinned test_review_prompt_template_parity -q, python3 scripts/run_tests_parallel.py, uvx ruff@0.16.0 check .
 - PRs:

--- a/.flow/tasks/fn-210-comment-as-alibi-finding-class-in-code.1.md
+++ b/.flow/tasks/fn-210-comment-as-alibi-finding-class-in-code.1.md
@@ -1,0 +1,18 @@
+---
+satisfies: [R1, R2, R3, R4]
+---
+# fn-210-comment-as-alibi-finding-class-in-code.1 Implement Comment-as-alibi finding class in code review prompts
+
+## Description
+TBD
+
+## Acceptance
+Every R-ID in the parent spec's ## Acceptance Criteria is satisfied; judge this task against the spec's criteria directly.
+
+## Done summary
+TBD
+
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the flow-next.
 
 ### Changed
 
+- **A workaround wearing a justifying comment no longer sails through code review as well-documented.** Implementation and standalone review now treat that comment as a signal on the underlying code. Severity is judged from the workaround, not the prose; rewriting or deleting the comment while keeping the hack does not resolve the finding. The fix is the code, or the constraint encoded as an assert, a test, or a lint rule. Licensed comments stay unflagged: license headers, external-constraint notes, lint suppressions with reasons, public API contracts, issue links.
 - **Review bots can no longer hold a merge hostage on process ceremony.** Decisions recorded in a spec's Decision Context (or ruled by the maintainer on the PR) are settled: the plan-review and completion-review prompts gained the settled-decisions rule the impl-review prompt already carried, and all three now state that process-compliance observations — checklist ceremony, dogfood records, handoff paperwork — are FYI, never blocking. The recommended `land.reviewTrigger` text tells external bots the same. Conduct checklists remain review rubrics; the mandatory dogfood-and-record handoff step is removed from the maintainer docs.
 
 ## [flow-next 4.9.0] - 2026-08-29

--- a/plugins/flow-next/codex/skills/flow-next-impl-review/references/impl-review-prompt.md
+++ b/plugins/flow-next/codex/skills/flow-next-impl-review/references/impl-review-prompt.md
@@ -85,6 +85,15 @@ or matching `knowledge/decisions` entry is FYI, never blocking. Process-complian
 observations (checklist ceremony, dogfood records, handoff paperwork) are likewise
 FYI, never blocking — the maintainer decides when a change lands.
 
+**Comment-as-alibi:** A comment that exists to justify a workaround or narrate
+around a hack is itself a finding: it flags the underlying code. Judge severity
+from the workaround, not the prose — well-written justification does not lower
+it. Rewriting or deleting the comment while keeping the workaround does not
+resolve the finding; the fix is the code, or the constraint encoded as an
+assert, a test, or a lint rule. Never flag licensed comments: license headers,
+external-constraint notes, lint suppressions with reasons, public API
+contracts, issue links.
+
 {smell_baseline_block}{r_id_coverage_block}
 {confidence_rubric_block}
 {classification_rubric_block}

--- a/plugins/flow-next/codex/skills/flow-next-impl-review/references/standalone-review-prompt.md
+++ b/plugins/flow-next/codex/skills/flow-next-impl-review/references/standalone-review-prompt.md
@@ -51,6 +51,15 @@ Do NOT mark NEEDS_WORK for:
 - Style nitpicks in files you didn't change
 
 You MAY mention these as "FYI" observations without affecting the verdict.
+
+**Comment-as-alibi:** A comment that exists to justify a workaround or narrate
+around a hack is itself a finding: it flags the underlying code. Judge severity
+from the workaround, not the prose — well-written justification does not lower
+it. Rewriting or deleting the comment while keeping the workaround does not
+resolve the finding; the fix is the code, or the constraint encoded as an
+assert, a test, or a lint rule. Never flag licensed comments: license headers,
+external-constraint notes, lint suppressions with reasons, public API
+contracts, issue links.
 {smell_baseline_block}
 {r_id_coverage_block}
 {confidence_rubric_block}

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -9111,6 +9111,15 @@ or matching `knowledge/decisions` entry is FYI, never blocking. Process-complian
 observations (checklist ceremony, dogfood records, handoff paperwork) are likewise
 FYI, never blocking — the maintainer decides when a change lands.
 
+**Comment-as-alibi:** A comment that exists to justify a workaround or narrate
+around a hack is itself a finding: it flags the underlying code. Judge severity
+from the workaround, not the prose — well-written justification does not lower
+it. Rewriting or deleting the comment while keeping the workaround does not
+resolve the finding; the fix is the code, or the constraint encoded as an
+assert, a test, or a lint rule. Never flag licensed comments: license headers,
+external-constraint notes, lint suppressions with reasons, public API
+contracts, issue links.
+
 {smell_baseline_block}{r_id_coverage_block}
 {confidence_rubric_block}
 {classification_rubric_block}
@@ -9197,6 +9206,15 @@ Do NOT mark NEEDS_WORK for:
 - Style nitpicks in files you didn't change
 
 You MAY mention these as "FYI" observations without affecting the verdict.
+
+**Comment-as-alibi:** A comment that exists to justify a workaround or narrate
+around a hack is itself a finding: it flags the underlying code. Judge severity
+from the workaround, not the prose — well-written justification does not lower
+it. Rewriting or deleting the comment while keeping the workaround does not
+resolve the finding; the fix is the code, or the constraint encoded as an
+assert, a test, or a lint rule. Never flag licensed comments: license headers,
+external-constraint notes, lint suppressions with reasons, public API
+contracts, issue links.
 {smell_baseline_block}
 {r_id_coverage_block}
 {confidence_rubric_block}

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "62c979b0ffbe1e3aa22261fb0ba25d257523c5255a3c5f9fcfd15a3bc9cac601"
+      "sha256": "23f6958de1f141a90e281eabb9e0dc8ca193be888c4e0c1d4afa2037ec285827"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/skills/flow-next-impl-review/references/impl-review-prompt.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/references/impl-review-prompt.md
@@ -85,6 +85,15 @@ or matching `knowledge/decisions` entry is FYI, never blocking. Process-complian
 observations (checklist ceremony, dogfood records, handoff paperwork) are likewise
 FYI, never blocking — the maintainer decides when a change lands.
 
+**Comment-as-alibi:** A comment that exists to justify a workaround or narrate
+around a hack is itself a finding: it flags the underlying code. Judge severity
+from the workaround, not the prose — well-written justification does not lower
+it. Rewriting or deleting the comment while keeping the workaround does not
+resolve the finding; the fix is the code, or the constraint encoded as an
+assert, a test, or a lint rule. Never flag licensed comments: license headers,
+external-constraint notes, lint suppressions with reasons, public API
+contracts, issue links.
+
 {smell_baseline_block}{r_id_coverage_block}
 {confidence_rubric_block}
 {classification_rubric_block}

--- a/plugins/flow-next/skills/flow-next-impl-review/references/standalone-review-prompt.md
+++ b/plugins/flow-next/skills/flow-next-impl-review/references/standalone-review-prompt.md
@@ -51,6 +51,15 @@ Do NOT mark NEEDS_WORK for:
 - Style nitpicks in files you didn't change
 
 You MAY mention these as "FYI" observations without affecting the verdict.
+
+**Comment-as-alibi:** A comment that exists to justify a workaround or narrate
+around a hack is itself a finding: it flags the underlying code. Judge severity
+from the workaround, not the prose — well-written justification does not lower
+it. Rewriting or deleting the comment while keeping the workaround does not
+resolve the finding; the fix is the code, or the constraint encoded as an
+assert, a test, or a lint rule. Never flag licensed comments: license headers,
+external-constraint notes, lint suppressions with reasons, public API
+contracts, issue links.
 {smell_baseline_block}
 {r_id_coverage_block}
 {confidence_rubric_block}

--- a/plugins/flow-next/tests/fixtures/review_prompts/impl.txt
+++ b/plugins/flow-next/tests/fixtures/review_prompts/impl.txt
@@ -104,6 +104,15 @@ or matching `knowledge/decisions` entry is FYI, never blocking. Process-complian
 observations (checklist ceremony, dogfood records, handoff paperwork) are likewise
 FYI, never blocking — the maintainer decides when a change lands.
 
+**Comment-as-alibi:** A comment that exists to justify a workaround or narrate
+around a hack is itself a finding: it flags the underlying code. Judge severity
+from the workaround, not the prose — well-written justification does not lower
+it. Rewriting or deleting the comment while keeping the workaround does not
+resolve the finding; the fix is the code, or the constraint encoded as an
+assert, a test, or a lint rule. Never flag licensed comments: license headers,
+external-constraint notes, lint suppressions with reasons, public API
+contracts, issue links.
+
 
 ## Code-smell baseline (always-on, judgement calls — repo standards override; skip what tooling enforces)
 Beyond correctness, name any of these you spot and quote the hunk (each a heuristic, never a hard violation):

--- a/plugins/flow-next/tests/fixtures/review_prompts/impl_empty_optional.txt
+++ b/plugins/flow-next/tests/fixtures/review_prompts/impl_empty_optional.txt
@@ -89,6 +89,15 @@ or matching `knowledge/decisions` entry is FYI, never blocking. Process-complian
 observations (checklist ceremony, dogfood records, handoff paperwork) are likewise
 FYI, never blocking — the maintainer decides when a change lands.
 
+**Comment-as-alibi:** A comment that exists to justify a workaround or narrate
+around a hack is itself a finding: it flags the underlying code. Judge severity
+from the workaround, not the prose — well-written justification does not lower
+it. Rewriting or deleting the comment while keeping the workaround does not
+resolve the finding; the fix is the code, or the constraint encoded as an
+assert, a test, or a lint rule. Never flag licensed comments: license headers,
+external-constraint notes, lint suppressions with reasons, public API
+contracts, issue links.
+
 
 ## Code-smell baseline (always-on, judgement calls — repo standards override; skip what tooling enforces)
 Beyond correctness, name any of these you spot and quote the hunk (each a heuristic, never a hard violation):

--- a/plugins/flow-next/tests/fixtures/review_prompts/standalone.txt
+++ b/plugins/flow-next/tests/fixtures/review_prompts/standalone.txt
@@ -62,6 +62,15 @@ Do NOT mark NEEDS_WORK for:
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 
+**Comment-as-alibi:** A comment that exists to justify a workaround or narrate
+around a hack is itself a finding: it flags the underlying code. Judge severity
+from the workaround, not the prose — well-written justification does not lower
+it. Rewriting or deleting the comment while keeping the workaround does not
+resolve the finding; the fix is the code, or the constraint encoded as an
+assert, a test, or a lint rule. Never flag licensed comments: license headers,
+external-constraint notes, lint suppressions with reasons, public API
+contracts, issue links.
+
 ## Code-smell baseline (always-on, judgement calls — repo standards override; skip what tooling enforces)
 Beyond correctness, name any of these you spot and quote the hunk (each a heuristic, never a hard violation):
 Long Method · Large Class · Long Parameter List · Duplicated Code · Feature Envy (uses another object's data more than its own) · Data Clumps (same values always passed together — wants a type) · Primitive Obsession (bare primitives where a small type belongs) · Speculative Generality · Middle Man / pass-through (forwards the same arguments to another call of the same shape — a layer hiding nothing).

--- a/plugins/flow-next/tests/fixtures/review_prompts/standalone_no_focus.txt
+++ b/plugins/flow-next/tests/fixtures/review_prompts/standalone_no_focus.txt
@@ -57,6 +57,15 @@ Do NOT mark NEEDS_WORK for:
 
 You MAY mention these as "FYI" observations without affecting the verdict.
 
+**Comment-as-alibi:** A comment that exists to justify a workaround or narrate
+around a hack is itself a finding: it flags the underlying code. Judge severity
+from the workaround, not the prose — well-written justification does not lower
+it. Rewriting or deleting the comment while keeping the workaround does not
+resolve the finding; the fix is the code, or the constraint encoded as an
+assert, a test, or a lint rule. Never flag licensed comments: license headers,
+external-constraint notes, lint suppressions with reasons, public API
+contracts, issue links.
+
 ## Code-smell baseline (always-on, judgement calls — repo standards override; skip what tooling enforces)
 Beyond correctness, name any of these you spot and quote the hunk (each a heuristic, never a hard violation):
 Long Method · Large Class · Long Parameter List · Duplicated Code · Feature Envy (uses another object's data more than its own) · Data Clumps (same values always passed together — wants a type) · Primitive Obsession (bare primitives where a small type belongs) · Speculative Generality · Middle Man / pass-through (forwards the same arguments to another call of the same shape — a layer hiding nothing).

--- a/plugins/flow-next/tests/test_prompt_text_pinned.py
+++ b/plugins/flow-next/tests/test_prompt_text_pinned.py
@@ -88,8 +88,10 @@ PROMPT_HASHES = {
         "a4b3105a7a8a3a56ba21d035d89dfc5cc62a496f4e1317b00fa89b01e197aafc",
     "CONFIDENCE_RUBRIC_BLOCK":
         "b8cc9e9594a3fed35498040e222bc9000333f4407f48374464115a69c231ae15",
+    # fn-210.1: comment-as-alibi finding class (workaround-justifying comments
+    # flag the underlying code; keep-list copied from the worker authoring rule).
     "IMPL_REVIEW_PROMPT_FALLBACK":
-        "5d45bb43b6983eeac8c0eeaa5a3298eb131e6f0d7625609ad9f79eba4904ca4e",
+        "983a06432cd3f94d1c2f84247ba1fda8818d21a779fbc4ad41c28465b27ffc4d",
     "PLAN_QUALITY_BLOCK":
         "0cfb49bfadf0be45e5c8036950d34698b5ae3bbccf24a90564983e13d0a1192f",
     "PLAN_REVIEW_PROMPT_FALLBACK":
@@ -106,8 +108,9 @@ PROMPT_HASHES = {
         "0fcf594a970ca41958003e4a41f99f0b8d590704d9c1ef32e47cd80722c68db9",
     "SPEC_SKELETON_TEMPLATE":
         "181c5cd5cba913346dc8c1800871dd42d139321319f86b80a67248ca15063ead",
+    # fn-210.1: same comment-as-alibi finding class as impl-review.
     "STANDALONE_REVIEW_PROMPT_FALLBACK":
-        "6f366a927f449312e623220362e9eb63351f5b8dd427e5669b236a362bad1357",
+        "08864bd5ede15540cd59947e2155d7ae8e895182b4028a23faced216d79760c8",
     # Condensation of validate-pass.md, NOT a copy of it (#118).
     "VALIDATOR_TEMPLATE_FALLBACK":
         "558ab25ab09ade0e315d924e72615c76f4ac8c9348cf60cfbfd761896664a36c",
@@ -173,9 +176,9 @@ TEMPLATE_HASHES = {
     "plugins/flow-next/skills/flow-next-impl-review/deep-passes.md":
         "41f7aa18ca28c48ec6ab27fac0c3fd18224232a76e1fbc6cef631435370dfc58",
     "plugins/flow-next/skills/flow-next-impl-review/references/impl-review-prompt.md":
-        "5d45bb43b6983eeac8c0eeaa5a3298eb131e6f0d7625609ad9f79eba4904ca4e",
+        "983a06432cd3f94d1c2f84247ba1fda8818d21a779fbc4ad41c28465b27ffc4d",
     "plugins/flow-next/skills/flow-next-impl-review/references/standalone-review-prompt.md":
-        "6f366a927f449312e623220362e9eb63351f5b8dd427e5669b236a362bad1357",
+        "08864bd5ede15540cd59947e2155d7ae8e895182b4028a23faced216d79760c8",
     "plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md":
         "dfef7509111bbaac438d85149a84ee3fc85bf407b3e499605d554bad9a8664fb",
     "plugins/flow-next/skills/flow-next-spec-completion-review/references/completion-review-prompt.md":


### PR DESCRIPTION
# Comment-as-alibi finding class in code review prompts

The worker's authoring rule "Comments are not alibis" (shipped 4.8.0) forbids comments that exist to justify a workaround — but nothing on the review side checked it, so a workaround wearing a paragraph-long justification sailed through review as "well documented."

> **Spec:** [fn-210-comment-as-alibi-finding-class-in-code](https://github.com/gmickel/flow-next/blob/ffaa31f01897594235f907dfe6c112a729f904de/.flow/specs/fn-210-comment-as-alibi-finding-class-in-code.md)
> **Branch:** `fn-210-comment-as-alibi-finding-class-in-code` → `origin/main`
> **Tasks:** 1 completed
> **R-ID coverage:** 4/4 evidenced

## TL;DR

- Both diff-reviewing prompts (impl-review and standalone-review) now name **comment-as-alibi** as a finding class: a comment that exists to justify a workaround flags the underlying code for review.
- Severity is judged from the workaround, not the prose — and rewriting or deleting the comment while keeping the hack does not resolve the finding.
- The keep-list (license headers, external-constraint notes, lint suppressions with reasons, public API contracts, issue links) is copied verbatim from the worker's authoring rule, so author and reviewer never disagree about which comments are licensed.

## Not in this PR (by design)

- No new skill, agent, or sticky comment-review overlay.
- No `.flow/criteria.md` G-ID.
- No change to the worker's authoring rule (already shipped) beyond keeping the keep-list identical.
- Plan-review and completion-review prompts untouched — they judge plans and coverage, not diff hunks.
- No version bump in this change (batched release rule).

## The change, top to bottom

The review prompts now enforce the rule the worker already follows: a comment that exists to justify a workaround flags the underlying code, and the reviewer judges the workaround - not the prose.

| Proof | Value | Sources |
|---|---|---|
| Artifact | `fn-210-aid-ffaa31f0-1` | artifact identity |
| Base commit | `21ea4d06d468c02ff883e906799a5eb1b41d3f82` | artifact currentness |
| Head commit | `ffaa31f01897594235f907dfe6c112a729f904de` | artifact identity |
| Human-review lines | 48 | deterministic file stats |
| Canonical files | 5 | deterministic membership |
| Total files | 16 | deterministic membership |
| Acceptance criteria evidenced | 4/4 (R1-R4) | source:src-r1, source:src-r2, source:src-r3, source:src-r4, source:src-task |
| Prompt integrity | hash pins + template byte-parity green | source:src-task |
| Full gate | 4545 tests + ruff 0.16.0 green | source:src-task |
| Evidence commit | 27fc137e | source:src-commit |

**The authoring rule had no reviewer-side check** — The worker rule forbidding workaround-justifying comments (shipped 4.8.0) was enforced only by the agent that wrote the comment - the review prompts never named the pattern, so a workaround wearing a paragraph of justification read as well-documented.

**Step 1 — Name the finding class in both diff-reviewing prompts** (R1, R2): An identical Comment-as-alibi block lands in the impl-review and standalone-review prompts: the justifying comment flags the underlying code, severity is judged from the workaround, and the keep-list is copied verbatim from the worker rule so author and reviewer never disagree. Constants and on-disk templates edited together (byte-parity).

| File | Purpose | +/- |
|---|---|---:|
| [`impl-review-prompt.md`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-760621c56c1c88a23de12d7cad07702a45a5c2312439aeaa73cc117d0faed362) | Finding-class block after the Settled-plan rule | +9/-0 |
| [`standalone-review-prompt.md`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-61f700be5f60ab1f78fa600fa54f6c85926a8dfddc024e9a2c152af0b9fa4b2e) | Same block after the FYI guidance | +9/-0 |
| [`flowctl.py`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-a52f4f2101d1a9031615badb0a45084834516bcb0b6ec993a50076403226568d) | Both FALLBACK constants updated byte-identically to their templates | +18/-0 |
| codex mirror (2 files) + `MANIFEST.json` | Regenerated by `sync-codex.sh` (generated — skim) | +19/-1 |

**Step 2 — Update the deliberate-change guards in the same commit** (R3, R4): The prompt-hash pins and the four rendered-prompt fixtures are updated alongside the prompt edit, and the CHANGELOG gains the user-outcome-first Unreleased entry.

| File | Purpose | +/- |
|---|---|---:|
| [`test_prompt_text_pinned.py`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-2475b77902597616d0fd6c6ab558e0a6572036d4c24d543a74a13537e29e7129) | New SHA-256 pins for the two changed constants, with fn-210 rationale comments | +7/-4 |
| fixtures/review_prompts (4 files) | Regenerated rendered fixtures (mechanical — skim) | +36/-0 |
| [`CHANGELOG.md`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) | Unreleased entry, user-outcome-first | +1/-0 |
| `.flow/` spec + task files (4) | Task-state, not hand-written code (skim) | +77/-6 |

**Verify — what ran**: Focused prompt-integrity suites (pin + template parity), the full 4545-test parallel suite, and pinned ruff 0.16.0 - all green; `sync-codex.sh` ran twice idempotently.

## Critical changes

- **High-churn:** [`.flow/specs/fn-210-comment-as-alibi-finding-class-in-code.md`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-3da0954e4590a67e09cc926d6993cbe02caf6da8141016db4380bc70482fc8bc) (+40/-0 lines) — the spec itself (no-plan route input)
- **High-churn:** [`plugins/flow-next/scripts/flowctl.py`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-a52f4f2101d1a9031615badb0a45084834516bcb0b6ec993a50076403226568d) (+18/-0 lines) — the two embedded prompt constants
- **High-churn:** [`.flow/tasks/fn-210-comment-as-alibi-finding-class-in-code.1.md`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-8b5f0a6314c962d89261cfbe5134e5427fd9eb0877fded2347db1f78fdf22893) (+17/-0 lines) — the minted implicit task + done receipt
- **High-churn:** [`.flow/tasks/fn-210-comment-as-alibi-finding-class-in-code.1.json`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-a6aea0585f1c4ea63796a1a330f50f30c21633ec8e91a998d0544a54e06b004f) (+14/-0 lines) — task sidecar
- **High-churn:** [`.flow/specs/fn-210-comment-as-alibi-finding-class-in-code.json`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-579db1c6abe25067b7b15b57c0715bd76f305784ad2285476c013e7a5613947f) (+6/-6 lines) — spec sidecar

## How to review this PR

The pipeline already verified this — you don't re-check it from scratch:
- **Tests / gates:** focused prompt-integrity suites (pin + template parity), the full 4545-test parallel suite, and pinned ruff 0.16.0 — all green; `sync-codex.sh` ran twice idempotently
- **R-ID coverage:** 4/4 acceptance criteria evidenced
- **Cross-model review:** no cross-model review recorded on this PR (in-host conductor review, verdict SHIP — see the task done receipt)

Your job — the calls the pipeline can't make:
- Line-review the **Must review** bucket below — the two prompt templates and the constant edits are the whole judgment surface.
- Spot-check the verified claims above; sample, don't re-run everything.
- Own what machines can't judge: is the finding-class prose calibrated right (workaround-flagging without nit-flagging)?

## Review plan

### Must review (~25%)

- [ ] 🔴 [`plugins/flow-next/skills/flow-next-impl-review/references/impl-review-prompt.md`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-760621c56c1c88a23de12d7cad07702a45a5c2312439aeaa73cc117d0faed362) — new reviewer-facing prompt prose (high-churn signal) — Does the finding class flag workarounds without licensing nit-hunts on ordinary comments? — open the `**Comment-as-alibi:**` block
- [ ] 🔴 [`plugins/flow-next/skills/flow-next-impl-review/references/standalone-review-prompt.md`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-61f700be5f60ab1f78fa600fa54f6c85926a8dfddc024e9a2c152af0b9fa4b2e) — same prose on the second review surface — Is the block byte-identical in intent to the impl one, keep-list included? — open the `**Comment-as-alibi:**` block
- [ ] 🔴 [`plugins/flow-next/scripts/flowctl.py`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-a52f4f2101d1a9031615badb0a45084834516bcb0b6ec993a50076403226568d) — embedded constants must mirror the templates (high-churn signal) — Are both FALLBACK constants byte-identical to their template files? — open `IMPL_REVIEW_PROMPT_FALLBACK` / `STANDALONE_REVIEW_PROMPT_FALLBACK`
- [ ] 🔴 [`plugins/flow-next/tests/test_prompt_text_pinned.py`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-2475b77902597616d0fd6c6ab558e0a6572036d4c24d543a74a13537e29e7129) — deliberate-change tripwire updated — Do the new pins cover exactly the two changed constants + their templates, nothing else? — open `PROMPT_HASHES` / `TEMPLATE_HASHES`

### Spot-check

- [ ] 🟡 [`CHANGELOG.md`](https://github.com/gmickel/flow-next/commit/27fc137ebdc1c77b2f5f1a63a196c33578de7245#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) — one Unreleased bullet, user-outcome-first

### Safe to skim (~75%)

- [ ] ⚪ 2 codex mirror prompt copies + `MANIFEST.json` — regenerated by `sync-codex.sh`, guard-verified — skim
- [ ] ⚪ 4 `tests/fixtures/review_prompts/*.txt` — regenerated rendered fixtures, parity-tested — skim
- [ ] ⚪ 4 `.flow/` spec + task files — task-state, not hand-written code — skim

## Structural changes

The change lands in five areas, all fanning out from one prompt edit: the two review-prompt templates plus their embedded constants in `plugins/flow-next/scripts/flowctl.py` carry the new finding class; `plugins/flow-next/tests/test_prompt_text_pinned.py` and the four rendered fixtures under `plugins/flow-next/tests/fixtures/review_prompts/` absorb it into the deliberate-change guards; the codex mirror copies are regenerated; `CHANGELOG.md` records it; and the `.flow/` spec and task files are the no-plan-route bookkeeping. No module gains or loses a dependency — the fan-out is one edit propagating through its derived surfaces.

```mermaid
graph TB
  spec["fn-210 comment-as-alibi"]
  spec --> prompts["review prompts (2 templates + flowctl.py constants)"]
  spec --> guards["prompt-integrity guards (hash pins + 4 fixtures)"]
  spec --> mirror["codex mirror (2 copies + MANIFEST)"]
  spec --> changelog["CHANGELOG.md"]
  spec --> state[".flow spec + task files (4)"]
```

---

*Generated by `/flow-next:make-pr` from [fn-210-comment-as-alibi-finding-class-in-code](https://github.com/gmickel/flow-next/blob/ffaa31f01897594235f907dfe6c112a729f904de/.flow/specs/fn-210-comment-as-alibi-finding-class-in-code.md) against `origin/main` on 2026-08-29.*
<!-- flow-next:make-pr spec=fn-210-comment-as-alibi-finding-class-in-code base=origin/main -->
