### PR TITLE
fix(skills): quote flow-next-features description so frontmatter parses (#389)

### DIFF
--- a/plugins/flow-next/skills/flow-next-features/SKILL.md
+++ b/plugins/flow-next/skills/flow-next-features/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flow-next-features
-description: Seed or maintain the committed user-POV feature map at `.flow/features/` so QA and drive reuse how a user reaches each feature. Two state-resolved modes: no `.flow/features/` (or explicit init intent) seeds it; a present map maintains it. Triggers on /flow-next:features, "seed the feature map", "maintain the feature map", "feature map", "init features". Never dispatched by pilot, land, Ralph, or any autonomous driver.
+description: 'Seed or maintain the committed user-POV feature map at `.flow/features/` so QA and drive reuse how a user reaches each feature. Two state-resolved modes: no `.flow/features/` (or explicit init intent) seeds it; a present map maintains it. Triggers on /flow-next:features, "seed the feature map", "maintain the feature map", "feature map", "init features". Never dispatched by pilot, land, Ralph, or any autonomous driver.'
 user-invocable: false
 allowed-tools: AskUserQuestion, Read, Bash, Grep, Glob, Write, Edit, Task
 ---


### PR DESCRIPTION
Fixes #389.

`skills/flow-next-features/SKILL.md` line 3 is an unquoted plain scalar containing a colon-space:

```yaml
description: ... each feature. Two state-resolved modes: no `.flow/features/` (or explicit init intent) seeds it; ...
```

YAML forbids `: ` inside a plain scalar, so the whole frontmatter block fails to parse and the skill loads with empty metadata — `name`, `description`, `user-invocable` and `allowed-tools` all silently dropped. The skill therefore has no description to be matched on and never activates, while still appearing installed.

## The change

One line. The description text is byte-identical; it is only wrapped in single quotes.

Single rather than double because the value contains double quotes (`"seed the feature map"`, `"feature map"`, `"init features"`) and no apostrophes. That mirrors `flow-next-deps`, `flow-next-prose`, `flow-next-strategy`, `flow-next-visual` and `flow-next`, which already double-quote for the opposite reason — theirs contain apostrophes.

`flow-next-features` is the only skill in the plugin whose unquoted description contains `: `, so no other file needs this.

## Verification

Before, on `main` @ `9b4e29e`:

```
$ claude plugin validate plugins/flow-next
✘ Found 1 error:
  ❯ frontmatter: YAML frontmatter failed to parse: YAML Parse error: Unexpected token.
    At runtime this skill loads with empty metadata (all frontmatter fields silently dropped).
✘ Validation failed
```

After:

```
$ claude plugin validate plugins/flow-next
✔ Validation passed
```

## Scope

Introduced in e646cf6 (#384) at 4.9.1, untouched by #385, still present at 4.11.0 — every release the skill has shipped in.

Same class as #235 and #332, so it may be worth a CI step running `claude plugin validate` over `plugins/flow-next` to catch the next one. Happy to add that here or in a follow-up, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)