### PR TITLE
fix(flowctl): spec set-title re-derives a still-default branch_name on rename

### DIFF
--- a/.flow/config.json
+++ b/.flow/config.json
@@ -15,6 +15,7 @@
     "cleanReviewCommentPattern": "(Didn'?t find any( major)? issues|No( major)? issues found).*Reviewed commit|\\*\\*Code Review\\*\\*.*\\*\\*Completed\\*\\*",
     "mergeVerdictCommand": "",
     "patienceMinutes": 30,
+    "patienceMinutesAfterReview": 10,
     "release": true,
     "requestReviewers": "",
     "reviewSignal": "silence",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the flow-next.
 
 ### Fixed
 
-- **Renaming a spec no longer strands its branch name.** `flowctl spec set-title` renamed the id and files but left `branch_name` at the old slug, so a retitled spec silently dropped out of land's PR discovery and autonomous work named the wrong branch (caught by review on PR #395). A `branch_name` still at its create-time default now follows the rename; an explicit `set-branch` value is kept, and the JSON result reports `branch_name` and `branch_rederived`.
+- **Renaming a spec no longer strands its branch name.** `flowctl spec set-title` renamed the id and files but left `branch_name` at the old slug, so a retitled spec silently dropped out of land's PR discovery and autonomous work named the wrong branch (caught by review on PR #395). A `branch_name` that still equals the old spec id (its create-time default) now follows the rename; any other value is kept, and the JSON result reports `branch_name` and `branch_rederived`.
 
 ## [flow-next 4.14.0] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the flow-next.
 
+## Unreleased
+
+### Fixed
+
+- **Renaming a spec no longer strands its branch name.** `flowctl spec set-title` renamed the id and files but left `branch_name` at the old slug, so a retitled spec silently dropped out of land's PR discovery and autonomous work named the wrong branch (caught by review on PR #395). A `branch_name` still at its create-time default now follows the rename; an explicit `set-branch` value is kept, and the JSON result reports `branch_name` and `branch_rederived`.
+
 ## [flow-next 4.14.0] - 2026-09-04
 
 Multi-task specs build faster by default: `/flow-next:work` now schedules on the rolling frontier, the architecture the experimental `/flow-next:work-rolling` beta proved in the field, and the beta itself is gone.

--- a/plugins/flow-next/codex/docs/flow-next/flowctl.md
+++ b/plugins/flow-next/codex/docs/flow-next/flowctl.md
@@ -420,7 +420,7 @@ flowctl spec set-branch fn-1 --branch "fn-1-spec" [--json]
 
 ### spec set-title
 
-Rename a spec by setting a new title (slug + filenames update; the JSON sidecar's `id` field follows).
+Rename a spec by setting a new title (slug + filenames update; the JSON sidecar's `id` field follows). A `branch_name` still at its create-time default (the old spec id) follows the rename too; an explicit `set-branch` value is kept. The JSON result reports `branch_name` and `branch_rederived`.
 
 ```bash
 flowctl spec set-title fn-1 --title "New title" [--json]

--- a/plugins/flow-next/codex/docs/flow-next/flowctl.md
+++ b/plugins/flow-next/codex/docs/flow-next/flowctl.md
@@ -420,7 +420,7 @@ flowctl spec set-branch fn-1 --branch "fn-1-spec" [--json]
 
 ### spec set-title
 
-Rename a spec by setting a new title (slug + filenames update; the JSON sidecar's `id` field follows). A `branch_name` still at its create-time default (the old spec id) follows the rename too; an explicit `set-branch` value is kept. The JSON result reports `branch_name` and `branch_rederived`.
+Rename a spec by setting a new title (slug + filenames update; the JSON sidecar's `id` field follows). A `branch_name` that still equals the old spec id (its create-time default) follows the rename; any other value is kept. The JSON result reports `branch_name` and `branch_rederived`.
 
 ```bash
 flowctl spec set-title fn-1 --title "New title" [--json]

--- a/plugins/flow-next/docs/flowctl.md
+++ b/plugins/flow-next/docs/flowctl.md
@@ -417,7 +417,7 @@ flowctl spec set-branch fn-1 --branch "fn-1-spec" [--json]
 
 ### spec set-title
 
-Rename a spec by setting a new title (slug + filenames update; the JSON sidecar's `id` field follows).
+Rename a spec by setting a new title (slug + filenames update; the JSON sidecar's `id` field follows). A `branch_name` still at its create-time default (the old spec id) follows the rename too; an explicit `set-branch` value is kept. The JSON result reports `branch_name` and `branch_rederived`.
 
 ```bash
 flowctl spec set-title fn-1 --title "New title" [--json]

--- a/plugins/flow-next/docs/flowctl.md
+++ b/plugins/flow-next/docs/flowctl.md
@@ -417,7 +417,7 @@ flowctl spec set-branch fn-1 --branch "fn-1-spec" [--json]
 
 ### spec set-title
 
-Rename a spec by setting a new title (slug + filenames update; the JSON sidecar's `id` field follows). A `branch_name` still at its create-time default (the old spec id) follows the rename too; an explicit `set-branch` value is kept. The JSON result reports `branch_name` and `branch_rederived`.
+Rename a spec by setting a new title (slug + filenames update; the JSON sidecar's `id` field follows). A `branch_name` that still equals the old spec id (its create-time default) follows the rename; any other value is kept. The JSON result reports `branch_name` and `branch_rederived`.
 
 ```bash
 flowctl spec set-title fn-1 --title "New title" [--json]

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -31432,7 +31432,8 @@ def cmd_spec_set_title(args: argparse.Namespace) -> None:
     # branch_name defaults to the spec id at create time; a rename that left
     # it at the old slug silently broke land's PR discovery and autonomous
     # work's branch naming (observed on fn-218). Re-derive it ONLY when it
-    # still equals the old default - an explicit `set-branch` value is kept.
+    # still equals the old spec id (its create-time default); any other
+    # value - whatever set it - is kept.
     branch_rederived = spec_data.get("branch_name") == old_id
     if branch_rederived:
         spec_data["branch_name"] = new_id

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -31429,6 +31429,13 @@ def cmd_spec_set_title(args: argparse.Namespace) -> None:
     spec_data["id"] = new_id
     spec_data["title"] = args.title
     spec_data["spec_path"] = f"{FLOW_DIR}/{SPECS_DIR}/{new_id}.md"
+    # branch_name defaults to the spec id at create time; a rename that left
+    # it at the old slug silently broke land's PR discovery and autonomous
+    # work's branch naming (observed on fn-218). Re-derive it ONLY when it
+    # still equals the old default - an explicit `set-branch` value is kept.
+    branch_rederived = spec_data.get("branch_name") == old_id
+    if branch_rederived:
+        spec_data["branch_name"] = new_id
     spec_data["updated_at"] = now_iso()
     atomic_write_json(spec_json_parent / f"{new_id}.json", spec_data)
 
@@ -31493,6 +31500,8 @@ def cmd_spec_set_title(args: argparse.Namespace) -> None:
     }
     if updated_deps_in:
         result["updated_deps_in"] = updated_deps_in
+    result["branch_name"] = spec_data.get("branch_name")
+    result["branch_rederived"] = branch_rederived
 
     if args.json:
         json_output(result)

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "c4eb906b2f8f76dba9ee7bee39f032176b6f1d5b7da41e0e1a27d57aa3976e6c"
+      "sha256": "f8d49940c6822ac693ddeb60110b02277193459420475d97ba687ce42f89e77b"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "d1bca4cb5b4a5758466c98a117a418413b8be880eab640944eb0712b6811eacd"
+      "sha256": "c4eb906b2f8f76dba9ee7bee39f032176b6f1d5b7da41e0e1a27d57aa3976e6c"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/tests/test_spec_set_title_branch.py
+++ b/plugins/flow-next/tests/test_spec_set_title_branch.py
@@ -1,0 +1,113 @@
+"""``spec set-title`` re-derives the default ``branch_name`` on rename.
+
+``branch_name`` defaults to the spec id at create time. Renaming the spec used
+to leave it at the old slug, which silently broke land's PR discovery and
+autonomous work's branch naming (observed on fn-218 / PR #395). A rename now
+moves a still-default ``branch_name`` to the new id and keeps an explicit
+``set-branch`` value untouched. Routes through production argparse.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+HERE = Path(__file__).resolve()
+FLOWCTL_PY = HERE.parent.parent / "scripts" / "flowctl.py"
+
+
+def _load_flowctl() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "flowctl_spec_set_title_branch_under_test", FLOWCTL_PY
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+flowctl = _load_flowctl()
+
+
+class TestSpecSetTitleBranch(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self._cwd = os.getcwd()
+        os.chdir(self.root)
+        subprocess.run(
+            ["git", "init", "-q"], cwd=self.root, check=True, capture_output=True
+        )
+        code, out, err = self._run("init", "--json")
+        self.assertEqual(code, 0, err or out)
+        code, out, err = self._run(
+            "spec", "create", "--title", "Old title here", "--json"
+        )
+        self.assertEqual(code, 0, err or out)
+        self.spec_id = json.loads(out)["id"]
+
+    def tearDown(self) -> None:
+        os.chdir(self._cwd)
+        self._tmp.cleanup()
+
+    def _run(self, *argv: str) -> "tuple[int, str, str]":
+        out, err = io.StringIO(), io.StringIO()
+        code = 0
+        with mock.patch.object(sys, "argv", ["flowctl", *argv]):
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                try:
+                    flowctl.main()
+                except SystemExit as e:
+                    code = int(e.code or 0)
+        return code, out.getvalue(), err.getvalue()
+
+    def _spec_json(self, spec_id: str) -> dict:
+        return json.loads(
+            (self.root / ".flow" / "specs" / f"{spec_id}.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+    def test_default_branch_name_follows_rename(self) -> None:
+        self.assertEqual(self._spec_json(self.spec_id)["branch_name"], self.spec_id)
+        code, out, err = self._run(
+            "spec", "set-title", self.spec_id, "--title", "New title now", "--json"
+        )
+        self.assertEqual(code, 0, err or out)
+        result = json.loads(out)
+        new_id = result["new_id"]
+        self.assertNotEqual(new_id, self.spec_id)
+        self.assertTrue(result["branch_rederived"])
+        self.assertEqual(result["branch_name"], new_id)
+        self.assertEqual(self._spec_json(new_id)["branch_name"], new_id)
+
+    def test_explicit_branch_name_survives_rename(self) -> None:
+        code, out, err = self._run(
+            "spec", "set-branch", self.spec_id, "--branch", "feat/custom", "--json"
+        )
+        self.assertEqual(code, 0, err or out)
+        code, out, err = self._run(
+            "spec", "set-title", self.spec_id, "--title", "New title now", "--json"
+        )
+        self.assertEqual(code, 0, err or out)
+        result = json.loads(out)
+        self.assertFalse(result["branch_rederived"])
+        self.assertEqual(result["branch_name"], "feat/custom")
+        self.assertEqual(self._spec_json(result["new_id"])["branch_name"], "feat/custom")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Renaming a spec with `flowctl spec set-title` renamed the id and every file but left `branch_name` at the old slug. Land discovers PRs by that field and autonomous work names its branch from it, so a retitled spec silently dropped out of the ship loop. Review on #395 caught it on the fn-218 spec.

## What changed

- `cmd_spec_set_title` re-derives `branch_name` to the new id when it still equals the old default (the spec id at create time). An explicit `set-branch` value is untouched. The JSON result reports `branch_name` and `branch_rederived`.
- Regression test `test_spec_set_title_branch.py`: default follows the rename; explicit survives it.
- `docs/flowctl.md` set-title entry, CHANGELOG `## Unreleased` Fixed entry, tracker manifest regenerated, codex mirror resynced.
- Separate commit: `.flow/config.json` sets `land.patienceMinutesAfterReview` to 10 for this repo, so land measures its merge wait from the bot's clean head-current review instead of from every push.

## Verification

- `python3 -m unittest test_spec_set_title_branch test_task_set_title test_flowctl_surface` green
- `python3 scripts/run_tests_parallel.py`: 202 files, 4725 tests, 0 failures
- `uvx ruff@0.16.0 check .` clean; `sync-codex.sh` twice, idempotent

## Version note

Staged under `## Unreleased`; batched release per CLAUDE.md.

https://claude.ai/code/session_01LFQ82qrkyYrNeNS8UgtAFk
