### PR TITLE
chore(routing): reviewer and implementer on gpt-6-astra; fable alias in the codex mirror

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,8 +198,8 @@ _Scaffolded by `/flow-next:setup` as an example, then edited. This section is yo
 Grammar: `<tier>: <model>` or `<tier>: <model> at <effort>`. An absent tier means the session model; an unparseable line is ignored. Tier meanings: [`plugins/flow-next/docs/orchestration.md`](plugins/flow-next/docs/orchestration.md#tiers-what-kind-of-model-a-job-wants). How this harness reaches one: [`plugins/flow-next/docs/reach/`](plugins/flow-next/docs/reach/README.md).
 
 ```
-reviewer: gpt-5.6-sol at high
-implementer: gpt-5.6-terra at medium
+reviewer: gpt-6-astra at high
+implementer: gpt-6-astra at medium
 fast scout: haiku-4.5
 thinking scout: sonnet-5
 ```

--- a/scripts/sync-codex.sh
+++ b/scripts/sync-codex.sh
@@ -72,7 +72,7 @@ map_model() {
     return
   fi
   case "$claude_model" in
-    opus|claude-opus-*)
+    opus|claude-opus-*|fable|claude-fable-*)
       echo "$CODEX_MODEL_INTELLIGENT" ;;
     sonnet|claude-sonnet-*)
       if echo "$INTELLIGENT_SCOUTS" | grep -qw "$agent_name" 2>/dev/null; then


### PR DESCRIPTION
This repo's own model routing moves to GPT-6 Astra for the reviewer and implementer tiers, and the codex mirror learns the `fable` agent alias.

## What changed

- `CLAUDE.md` routing block: `reviewer: gpt-6-astra at high`, `implementer: gpt-6-astra at medium` (medium stays the documented floor for a bridged implementer). Scout tiers unchanged.
- `scripts/sync-codex.sh`: `fable|claude-fable-*` joins `opus|claude-opus-*` in the alias map, so an agent pinned to Fable on Claude Code lands on Codex's intelligent tier instead of the unknown-alias fallthrough. Mirror regenerated.

## Verification

- `./scripts/sync-codex.sh` twice, clean mirror diff on the second run
- `uvx ruff@0.16.0 check .` clean
- `python3 scripts/run_tests_parallel.py`: 203 files, 4741 tests, 0 failures

## Version note

No behaviour change for users; no version bump. The maintainer confirmed both ids are served in Claude Code and Codex today.

https://claude.ai/code/session_01LFQ82qrkyYrNeNS8UgtAFk
