### PR TITLE
refactor(python): remove dead paths and fix exposed regressions

### DIFF
--- a/.flow/specs/fn-224-refactorpython-remove-dead-paths-and.json
+++ b/.flow/specs/fn-224-refactorpython-remove-dead-paths-and.json
@@ -1,0 +1,24 @@
+{
+  "branch_name": "refactor/python-slop-review",
+  "created_at": "2026-09-05T11:40:05.563143Z",
+  "depends_on_epics": [],
+  "id": "fn-224-refactorpython-remove-dead-paths-and",
+  "next_task": 1,
+  "plan_review_status": "unknown",
+  "plan_reviewed_at": null,
+  "spec_path": ".flow/specs/fn-224-refactorpython-remove-dead-paths-and.md",
+  "status": "open",
+  "title": "refactor(python): remove dead paths and fix exposed regressions",
+  "tracker": {
+    "baseHashFlow": null,
+    "baseHashTracker": null,
+    "depRelations": [],
+    "id": null,
+    "identifier": null,
+    "lastSyncedAt": null,
+    "mergeBaseFlow": null,
+    "mergeBaseTracker": null,
+    "url": null
+  },
+  "updated_at": "2026-09-05T11:42:56.780956Z"
+}

--- a/.flow/specs/fn-224-refactorpython-remove-dead-paths-and.json
+++ b/.flow/specs/fn-224-refactorpython-remove-dead-paths-and.json
@@ -1,11 +1,60 @@
 {
   "branch_name": "refactor/python-slop-review",
+  "completion_review_status": "unknown",
+  "completion_reviewed_at": null,
   "created_at": "2026-09-05T11:40:05.563143Z",
+  "default_impl": null,
+  "default_review": null,
+  "default_sync": null,
   "depends_on_epics": [],
   "id": "fn-224-refactorpython-remove-dead-paths-and",
+  "impl_review_rounds": {
+    "fn-224-refactorpython-remove-dead-paths-and.1": 0
+  },
   "next_task": 1,
+  "plan_review_rounds": 0,
   "plan_review_status": "unknown",
   "plan_reviewed_at": null,
+  "review_attempts": [
+    {
+      "artifact_sha256": "df49a651050d134740719ae113e26c37e8322c3bd41170d3fe439a1e0b4fd278",
+      "backend": "codex",
+      "base_sha": "32f73742251dafd76e9799d6893518778c4e9408",
+      "counter_kind": "impl",
+      "effort": "high",
+      "failure_class": null,
+      "finalized": {
+        "digest": "complete",
+        "receipt": "complete",
+        "status": "not_applicable"
+      },
+      "forced": false,
+      "hash_epoch": 0,
+      "head_sha": "ff52732aef4ecf228712c51a757b17f02c75b7d3",
+      "head_sha_observed": true,
+      "kind": "impl",
+      "model": "gpt-6-astra",
+      "outcome": "verdict",
+      "output_bytes": 308214,
+      "output_sha256": "8dd33b538cdd4f28579931900eaa495deed5e0805b5fd1bcae7501f88f4d268b",
+      "reservation_id": "f6d0650eaab24956b9f37f552567bdaa",
+      "round_consumed": true,
+      "scope": "impl:fn-224-refactorpython-remove-dead-paths-and.1",
+      "superseded_by": null,
+      "task": "fn-224-refactorpython-remove-dead-paths-and.1",
+      "timestamp": "2026-09-08T11:05:55.773574Z",
+      "tool_calls": 21,
+      "verdict": "SHIP"
+    }
+  ],
+  "review_hash_epoch": {
+    "impl:fn-224-refactorpython-remove-dead-paths-and.1": 1
+  },
+  "review_pending_rounds": {},
+  "review_reservations": {},
+  "review_transport_failures": {
+    "impl:fn-224-refactorpython-remove-dead-paths-and.1": 0
+  },
   "spec_path": ".flow/specs/fn-224-refactorpython-remove-dead-paths-and.md",
   "status": "open",
   "title": "refactor(python): remove dead paths and fix exposed regressions",
@@ -20,5 +69,5 @@
     "mergeBaseTracker": null,
     "url": null
   },
-  "updated_at": "2026-09-05T11:42:56.780956Z"
+  "updated_at": "2026-09-08T11:05:55.781573Z"
 }

--- a/.flow/specs/fn-224-refactorpython-remove-dead-paths-and.md
+++ b/.flow/specs/fn-224-refactorpython-remove-dead-paths-and.md
@@ -1,0 +1,37 @@
+# Python simplification and regression fixes
+
+## Goal & Context
+
+Remove unnecessary Python machinery and fix defects exposed by a broad first-principles review of Flow-Next. Gordon requested GPT-6 Astra subagents, the deletion-first review rubric, regression evidence, and delivery through make-pr.
+
+## Architecture & Data Models
+
+Keep the stdlib CLI, provider package, and existing installer tooling. Delete demonstrably unused paths and consolidate repeated logic within existing boundaries. Preserve the review journal, provider adapters, filesystem guards, and historical evaluation evidence.
+
+## API Contracts
+
+Public CLI commands and output schemas remain compatible. Forced task takeover transfers ownership even with a custom note. Anonymous tracker HTTP requests do not resolve provider credentials. Encoded Basic credentials receive the same redaction protection as raw secrets. TOML normalization preserves unrelated tables. Tracker locks reject symlinked lock directories. Installer verification compares complete copied payloads. Evaluation read coverage derives from measured files.
+
+## Edge Cases & Constraints
+
+Python 3.11+, pure stdlib runtime. Preserve emitted review prompts byte for byte. Test malformed or missing config, takeover ownership transitions, anonymous versus authenticated requests, credential echoes, and commented TOML table boundaries. All tracker tests use fakes; no live tracker writes.
+
+## Acceptance Criteria
+
+- **R1:** Review the core CLI, review machinery, tracker integration, supporting Python tools, and test/evaluation infrastructure with GPT-6 Astra; record accepted and rejected candidates. No error surface beyond read-only inspection and local checks.
+- **R2:** Remove confirmed dead paths and simplify duplicate Python logic while preserving supported command and review contracts. Errors: existing invalid-input, storage, backend failure, and no-embed behavior remains covered by focused suites.
+- **R3:** Fix reproduced ownership, credential-policy/redaction, lock containment, TOML-preservation, and verification defects with meaningful regressions. Errors: unavailable credentials cannot block anonymous requests; unowned TOML data survives; custom notes preserve ownership transfer; symlinked lock parents cause no external writes; missing or extra installed payloads and missing required evaluation files cannot pass verification.
+- **R4:** Run affected regression suites, regenerate required artifacts idempotently, and pass the repository full suite and pinned Ruff check before opening the PR. Failed checks must be repaired or reported without claiming a green result.
+
+Standing criteria: G1 and G2.
+
+## Boundaries
+
+- Skill prose and prompt optimization.
+- New CLI commands, dependencies, configuration flags, or architectural extraction.
+- Rewriting historical evaluation results or implementing unrelated backlog specs.
+- Releases, merges, and live tracker mutations.
+
+## Decision Context
+
+Prefer deletion over simplification, simplification over optimization, and optimization over automation. Each edit needs caller evidence or a reproduced defect. Working journal and provider-specific behavior stays because its contracts justify the machinery. Review findings and regression evidence will be recorded in task summaries; this review does not claim exhaustive proof of all possible regressions.

--- a/.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.json
+++ b/.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.json
@@ -1,0 +1,14 @@
+{
+  "assignee": null,
+  "claim_note": "",
+  "claimed_at": null,
+  "created_at": "2026-09-05T11:40:15.842000Z",
+  "depends_on": [],
+  "id": "fn-224-refactorpython-remove-dead-paths-and.1",
+  "priority": null,
+  "spec": "fn-224-refactorpython-remove-dead-paths-and",
+  "spec_path": ".flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.md",
+  "status": "todo",
+  "title": "Review and simplify Python with regression evidence",
+  "updated_at": "2026-09-05T11:40:15.842000Z"
+}

--- a/.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.md
+++ b/.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.md
@@ -1,0 +1,18 @@
+---
+satisfies: [R1, R2, R3, R4]
+---
+# fn-224-refactorpython-remove-dead-paths-and.1 Review and simplify Python with regression evidence
+
+## Description
+Review core CLI, review dispatch, tracker integration, supporting tools, and test/evaluation infrastructure using GPT-6 Astra subagents. Implement only grounded deletions, simplifications, and reproduced fixes. Files: Python production code and focused tests; generated manifests/mirror only through generators. Record accepted/rejected findings and run focused suites plus python3 scripts/run_tests_parallel.py and uvx ruff@0.16.0 check .
+
+## Acceptance
+R1-R4 satisfied; Python changes preserve public contracts and prompt bytes, reproduced bugs have regression coverage, full repository checks pass, required generated artifacts are idempotent. G1/G2 apply.
+
+## Done summary
+TBD
+
+## Evidence
+- Commits:
+- Tests:
+- PRs:

--- a/.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.md
+++ b/.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.md
@@ -10,9 +10,42 @@ Review core CLI, review dispatch, tracker integration, supporting tools, and tes
 R1-R4 satisfied; Python changes preserve public contracts and prompt bytes, reproduced bugs have regression coverage, full repository checks pass, required generated artifacts are idempotent. G1/G2 apply.
 
 ## Done summary
-TBD
+### Result
 
+Five GPT-6 Astra subagents reviewed the Python CLI, backend dispatch, tracker package, supporting tools, and test/evaluation infrastructure. Implemented the confirmed findings and retained the components whose distinct contracts justify their complexity. Skill prose and emitted review prompts are unchanged.
+
+### Changes
+
+- Core CLI: removed the single-implementation StateStore abstract class and the shadowed timestamp parser; consolidated raw config reads through one reader and the existing snapshot; separated ownership transfer from claim-note selection so force plus a custom note assigns the current actor.
+- Review dispatch: removed unused prompt_fit/display_name registry fields and the unused third re-review prompt result; resolved receipt model/effort once while retaining Codex-specific rebinding.
+- Tracker: skipped credential resolution for anonymous HTTP; remembered reversible Jira Basic credentials for redaction; rejected symlinked chart-lock parent directories; deleted two helpers with no callers.
+- Supporting tools: fixed commented TOML table and array-table boundaries in hook normalization; removed an unconditional newline branch; replaced separate Cursor roster/hash checks with complete copied-file comparison; deleted an unreachable second permission-validation loop while retaining mapped-key enforcement.
+- Evaluation checks: measured required files now determine route accuracy, preventing missing common/backend files from producing a successful smaller-candidate verdict. A missing root continues to raise FileNotFoundError.
+- Test cleanup: the deliberately failing-kill fixture now registers parent-process cleanup immediately on launch, alongside its existing descendant cleanup. This prevents each suite run from leaving a sleeping orphan shard.
+- Added focused behavioral regressions, regenerated distribution hashes, and recorded user-visible fixes under Unreleased. No version bump.
+
+### Regression evidence
+
+New tests failed before their fixes for forced takeover with a custom note, anonymous credential resolution, encoded Basic redaction, both tracker lock entry points through a symlinked directory, missing/extra nested Cursor payload files, and missing required evaluation references. TOML failures were reproduced directly; tests cover valid parse results, preservation of unrelated content, and idempotency.
+
+Focused suites cover config fallbacks and sentinel semantics, task ownership, chart claims/locks, tracker executor/conformance/state, backend resolution, convergence caps/journals, prompt pins, no-embed dispatch, real Codex installation, Cursor payload verification, OpenCode permissions, and evaluation route measurement. The real Codex installer test passed after distribution regeneration.
+
+Two Codex sync runs passed their guards and produced identical output with no mirror diff. Repository-wide Ruff, diff whitespace, and spec validation passed. The full parallel suite passed 4,806 tests across 207 files, with 7 skips, zero failures, and zero errors. An initial full run caught a test-loader guard mismatch in the new Cursor test; switching to a normal scoped import fixed it, and the fresh full run passed. Post-run inspection found two orphan timeout-test parents from those runs; their exact temporary-corpus identities were verified before termination, and the fixture cleanup was fixed separately. All 30 affected runner tests passed afterward; process inspection found no remaining synthetic timeout shards, and the repository-wide Ruff check passed again.
+
+### Review disposition
+
+- Retained the shared backend driver; provider-specific transport, resume, effort, and sandbox handling have actual consumers. The old generic-runner backlog description predates the current shared implementation.
+- Retained journal recovery, transaction locks, no-clobber publication, chart serialization, and ownership checks. Architectural extraction remains separate backlog work.
+- Retained legacy persisted-layout normalization and tracker aliases. They support existing data rather than speculative compatibility.
+- Retained separate empty-object lookup semantics; merging both lookup helpers would change behavior.
+- Retained provider-specific status/resolution, claim ledgers, pagination bounds, test-runner process containment, Ralph guard parsing, bootstrap fast paths, and config ownership validation.
+- Preserved historical eval fixtures and negative results. A fixture-only skill-prose reduction assertion was noted but left outside this Python-product cleanup.
+- Astra peer review checked other agents' changes; this is a same-family second opinion, not a recorded cross-family implementation gate.
+
+### Delivery scope
+
+R1-R4 and G1/G2 addressed. The downstream documentation walk found existing command and safety contracts already describe the intended behavior; this PR restores them and changes no workflow, public configuration, or release version. Customer release announcements remain part of the separately authorized release. No live tracker mutations or external model evaluations ran.
 ## Evidence
-- Commits:
-- Tests:
+- Commits: b2969ec2b5385a3ee7c1896a7ecd6b99f118899f, 8193465f791a0e9862d0c9e72ee8e8e9ad498ea8
+- Tests: python3 scripts/run_tests_parallel.py: 4806 tests across 207 files; 0 failures, 0 errors, 7 skips, python3 -m unittest discover -s plugins/flow-next/tests -p test_run_tests_parallel.py: 30 passed after subsequent fixture-only cleanup; no orphan synthetic shards remain, uvx ruff@0.16.0 check .: passed after final edit, python3 scripts/gen_tracker_manifest.py and ./scripts/sync-codex.sh twice: passed; identical generated output, no Codex mirror diff, Focused pre/post regression suites passed, including real Codex installation (13 tests), prompt pins, no-embed dispatch, tracker execution, TOML preservation, Cursor payload and eval measurement checks, git diff --check and flowctl validate --spec fn-224-refactorpython-remove-dead-paths-and --json: passed
 - PRs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to the flow-next.
 ### Fixed
 
 - Windows Codex installs read and write config and role files as UTF-8 regardless of the system locale, preventing `UnicodeDecodeError` and preserving non-ASCII settings.
-
+- Forced task takeovers now transfer ownership when a custom claim note is supplied. Anonymous tracker uploads proceed without resolving provider credentials, echoed Jira Basic credentials are redacted, and tracker chart locks reject symlinked lock directories.
+- Codex hook normalization preserves unrelated settings after commented TOML table headers and array tables. Cursor install verification now detects missing or unexpected nested payload files.
 - Codex installs recover duplicate Flow-Next agent registrations left behind when opening comment markers were removed. The installer preserves unrelated settings and role overrides, places the thread limit in the correct table, and validates the merged config before replacing it with a private backup. Conflicting user-owned roles or malformed unrelated TOML stop the install instead of breaking Codex startup. Reported by @gmickel.
 
 ## [flow-next 4.16.0] - 2026-09-05

--- a/optimization/reached-path/plan_review_candidate.py
+++ b/optimization/reached-path/plan_review_candidate.py
@@ -82,22 +82,31 @@ def route_evidence(repo_root: Path) -> dict[str, Any]:
             100 * (b1_chars - candidate_chars) / b1_chars, 2
         )
         rows.append(candidate)
+    measured_paths = {
+        row["route"]: {file["path"] for file in row["metrics"]["files"]}
+        for row in rows
+    }
     accuracy = {
         "all_routes_have_common": all(
-            COMMON.as_posix() in row["required_reads"] for row in rows
+            COMMON.as_posix() in measured_paths[row["route"]] for row in rows
         ),
         "none_export_backend_cold": all(
             row["selected_backend"] is None
-            and all(backend_file(b).as_posix() in row["forbidden_reads"] for b in BACKENDS)
+            and all(
+                backend_file(b).as_posix() not in measured_paths[row["route"]]
+                for b in BACKENDS
+            )
             for row in rows
             if row["route"] in ("none", "export")
         ),
         "exactly_one_selected_backend": all(
             sum(
-                backend_file(b).as_posix() in row["required_reads"]
+                backend_file(b).as_posix() in measured_paths[row["route"]]
                 for b in BACKENDS
             )
             == 1
+            and backend_file(row["selected_backend"]).as_posix()
+            in measured_paths[row["route"]]
             for row in rows
             if row["route"] not in ("none", "export")
         ),

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -27,14 +27,13 @@ import tempfile
 import threading
 import unicodedata
 import uuid
-from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager, redirect_stdout, suppress
 from dataclasses import dataclass, field, replace as dataclass_replace
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, ContextManager, Optional, Sequence
+from typing import Any, Optional, Sequence
 
 
 # Cross-process locks use platform-native kernel locks. The kernel releases
@@ -960,41 +959,10 @@ def get_state_dir() -> Path:
     return get_flow_dir() / "state"
 
 
-# --- StateStore (runtime task state) ---
+# --- Runtime task state ---
 
 
-class StateStore(ABC):
-    """Abstract interface for runtime task state storage."""
-
-    @abstractmethod
-    def load_runtime(self, task_id: str) -> Optional[dict]:
-        """Load runtime state for a task. Returns None if no state file."""
-        ...
-
-    @abstractmethod
-    def save_runtime(self, task_id: str, data: dict) -> None:
-        """Save runtime state for a task."""
-        ...
-
-    @abstractmethod
-    def lock_task(self, task_id: str) -> ContextManager:
-        """Context manager for exclusive task lock."""
-        ...
-
-    @abstractmethod
-    def load_all_runtime(
-        self, task_ids: Optional[set[str]] = None
-    ) -> dict[str, dict]:
-        """Load readable runtime state, optionally restricted to task IDs."""
-        ...
-
-    @abstractmethod
-    def delete_runtime(self, task_id: str) -> None:
-        """Delete a task's runtime state when present."""
-        ...
-
-
-class LocalFileStateStore(StateStore):
+class LocalFileStateStore:
     """File-based state store with portable cross-process locking."""
 
     def __init__(self, state_dir: Path):
@@ -1754,21 +1722,7 @@ def deep_merge(base: dict, override: dict) -> dict:
 
 def load_flow_config() -> dict:
     """Load .flow/config.json, merging with defaults for missing keys."""
-    config_path = get_flow_dir() / CONFIG_FILE
-    defaults = get_default_config()
-    if not config_path.exists():
-        return _with_tracker_spec_ids_normalized(defaults)
-    try:
-        data = json.loads(config_path.read_text(encoding="utf-8"))
-        if isinstance(data, dict):
-            # fn-213: alias a retired persisted cleanReviewCommentPattern
-            # default to the current built-in (read-time; disk untouched).
-            return _with_retired_clean_review_pattern_upgraded(
-                _with_tracker_spec_ids_normalized(deep_merge(defaults, data))
-            )
-        return _with_tracker_spec_ids_normalized(defaults)
-    except (json.JSONDecodeError, Exception):
-        return _with_tracker_spec_ids_normalized(defaults)
+    return load_config_snapshot().merged
 
 
 def _walk_config_value(config, key: str, default=None):
@@ -1794,6 +1748,19 @@ def get_config(key: str, default=None):
 _CONFIG_RAW_SENTINEL = object()
 
 
+def _load_raw_flow_config() -> Optional[dict]:
+    """Read the persisted config object, or None when absent or unreadable."""
+    config_path = get_flow_dir() / CONFIG_FILE
+    if config_path.exists():
+        try:
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data
+        except Exception:
+            pass
+    return None
+
+
 def _get_config_from_file(key: str):
     """Probe the raw .flow/config.json for `key` without applying defaults.
 
@@ -1803,21 +1770,10 @@ def _get_config_from_file(key: str):
     set the key to None / false" from "key never written" — load-bearing
     for distinguishing unset keys from explicit false/null.
     """
-    config_path = get_flow_dir() / CONFIG_FILE
-    if not config_path.exists():
+    data = _load_raw_flow_config()
+    if data is None:
         return _CONFIG_RAW_SENTINEL
-    try:
-        data = json.loads(config_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, Exception):
-        return _CONFIG_RAW_SENTINEL
-    if not isinstance(data, dict):
-        return _CONFIG_RAW_SENTINEL
-    current = data
-    for part in key.split("."):
-        if not isinstance(current, dict) or part not in current:
-            return _CONFIG_RAW_SENTINEL
-        current = current[part]
-    return current
+    return _tree_probe(data, key)
 
 
 # --- Command-scoped config snapshot (fn-110.1) -----------------------------
@@ -1862,15 +1818,7 @@ def load_config_snapshot() -> ConfigSnapshot:
     thread the result through `resolve_config_key_for_read(..., snapshot=)`
     and the root/subtree emission paths instead of re-reading per key.
     """
-    config_path = get_flow_dir() / CONFIG_FILE
-    raw = None
-    if config_path.exists():
-        try:
-            data = json.loads(config_path.read_text(encoding="utf-8"))
-            if isinstance(data, dict):
-                raw = data
-        except (json.JSONDecodeError, Exception):
-            raw = None
+    raw = _load_raw_flow_config()
     defaults = get_default_config()
     if raw is None:
         merged = defaults
@@ -7921,8 +7869,8 @@ def is_sandbox_failure(exit_code: int, stdout: str, stderr: str) -> bool:
 # model). Every validation error lists the valid set sorted alphabetically so
 # users get a deterministic, copy-pasteable hint.
 #
-# fn-112 review-driver hooks (run_exec / resolve_spec / check_probe / gather_diff
-# / prompt_fit / …) are attached lazily by ``_wire_backend_review_hooks`` so this
+# fn-112 review-driver hooks (run_exec / resolve_spec / check_probe / …)
+# are attached lazily by ``_wire_backend_review_hooks`` so this
 # static table stays free of forward references to helpers defined later.
 #
 # Codex ``minimal`` effort caveat: passes codex config validation but the server
@@ -15020,18 +14968,6 @@ def _apply_parked_to_chart_body(md_text: str, parked: list) -> str:
     )
 
 
-def _parse_iso_ts(raw: Optional[str]) -> Optional[datetime]:
-    if not raw or not isinstance(raw, str):
-        return None
-    text = raw.strip()
-    if text.endswith("Z"):
-        text = text[:-1] + "+00:00"
-    try:
-        return datetime.fromisoformat(text)
-    except ValueError:
-        return None
-
-
 def _claim_age_hours(claimed_at: Optional[str]) -> Optional[float]:
     ts = _parse_iso_ts(claimed_at)
     if ts is None:
@@ -19534,7 +19470,7 @@ class TaskInventory:
         spec_ids: Optional[set[str]] = None,
         collect_consistency_errors: bool = False,
         collect_load_errors: bool = False,
-        state_store: Optional["StateStore"] = None,
+        state_store: Optional[LocalFileStateStore] = None,
     ) -> "TaskInventory":
         task_files = list(iter_task_json_files(flow_dir, spec_id=spec_id))
         if spec_ids is not None:
@@ -35462,28 +35398,23 @@ def cmd_start(args: argparse.Namespace) -> None:
 
         # Build runtime state updates
         runtime_updates = {**runtime, "status": "in_progress", "updated_at": now_iso()}
-        if not existing_assignee:
+        taking_over = bool(
+            args.force and existing_assignee and existing_assignee != current_actor
+        )
+        if not existing_assignee or reclaiming or taking_over:
             runtime_updates["assignee"] = current_actor
             runtime_updates["claimed_at"] = now_iso()
         if args.note:
             runtime_updates["claim_note"] = args.note
-            if reclaiming:
-                runtime_updates["assignee"] = current_actor
-                runtime_updates["claimed_at"] = now_iso()
         elif reclaiming:
             # Identity repair: distinct from the --force takeover note so the
             # record says which one happened.
-            runtime_updates["assignee"] = current_actor
-            runtime_updates["claimed_at"] = now_iso()
             runtime_updates["claim_note"] = (
                 f"Reclaimed from {existing_assignee} (identity repair)"
             )
-        elif args.force and existing_assignee and existing_assignee != current_actor:
+        elif taking_over:
             # Force override: note the takeover
-            runtime_updates["assignee"] = current_actor
-            runtime_updates["claimed_at"] = now_iso()
-            if not args.note:
-                runtime_updates["claim_note"] = f"Taken over from {existing_assignee}"
+            runtime_updates["claim_note"] = f"Taken over from {existing_assignee}"
 
         # Write inside lock
         store.save_runtime(args.id, runtime_updates)
@@ -42193,8 +42124,8 @@ def _rereview_prompt_pair(
     prior_findings: Optional[str],
     prior_items: Optional[dict],
     two_phase: bool,
-) -> tuple[str, Optional[str], str]:
-    """Build the (dispatch, injected, preamble) triple for one re-review round.
+) -> tuple[str, Optional[str]]:
+    """Build the (dispatch, injected) prompt pair for one re-review round.
 
     fn-169 R2. Shared by all three review handlers — implementation, plan, and
     completion — because the resume/injection contract is a property of the
@@ -42203,21 +42134,18 @@ def _rereview_prompt_pair(
     dispatch prompt carries the rendered priors and ``injected`` is None, which
     is byte-for-byte the pre-fn-169 behavior.
 
-    The third element is the preamble actually prefixed to the dispatch prompt;
-    cursor's argv fitter strips and re-fits exactly that string, and cursor is
-    never two-phase, so it always receives the full one.
     """
     preamble = build_rereview_preamble(
         files, review_type,
         prior_findings=prior_findings, prior_items=prior_items,
     )
     if not two_phase:
-        return preamble + prompt, None, preamble
+        return preamble + prompt, None
     lean = build_rereview_preamble(
         files, review_type,
         prior_findings=prior_findings, prior_items=prior_items, resumed=True,
     )
-    return lean + prompt, preamble + prompt, lean
+    return lean + prompt, preamble + prompt
 
 
 def _codex_run_exec(
@@ -42943,7 +42871,7 @@ def _load_epic_and_task_specs(
     return epic_spec_path, tasks_dir, epic_spec, task_specs, task_ids
 
 def _wire_backend_review_hooks() -> None:
-    """Attach run_exec / resolve_spec / check_probe / prompt-fit hooks.
+    """Attach run_exec / resolve_spec / check_probe hooks.
 
     Idempotent. Called at the top of cmd_backend_review so the static
     BACKEND_REGISTRY (defined before run_copilot_exec / resolve_* helpers)
@@ -42976,17 +42904,14 @@ def _wire_backend_review_hooks() -> None:
         "has_sandbox": True,
         "include_effort": True,
         "extract_review": extract_codex_final_message,
-        "display_name": "Codex",
         "cli_label": "codex exec",
         "no_verdict_label": "Codex",
-        # Prompt-fit: none (stdin delivery; no argv budget).
-        "prompt_fit": "none",
         # fn-187 R1: ON. The False here was never a decision — it mechanically
         # preserved pre-#296 behavior when the registry was extracted. codex exec
         # inherits the host AGENTS.md and (with the codex plugin installed) the
         # flow-next coordinator skill catalogs, which taught the reviewer to
-        # re-dispatch instead of declaring a verdict (#331). Delivery is stdin
-        # with prompt_fit "none", so the preamble costs no argv budget.
+        # re-dispatch instead of declaring a verdict (#331). Delivery is
+        # through stdin, so the preamble costs no argv budget.
         "needs_persona_override": True,
         # fn-215 R15: fan-out is a registry gate on the impl pipeline, never
         # inside _dispatch_backend_review (plan/completion share that helper).
@@ -43005,10 +42930,8 @@ def _wire_backend_review_hooks() -> None:
         "has_sandbox": False,
         "include_effort": True,
         "extract_review": lambda output: output,
-        "display_name": "Copilot",
         "cli_label": "copilot",
         "no_verdict_label": "Copilot",
-        "prompt_fit": "none",
         "needs_persona_override": False,
     })
     BACKEND_REGISTRY["cursor"].update({
@@ -43024,11 +42947,8 @@ def _wire_backend_review_hooks() -> None:
         "has_sandbox": False,
         "include_effort": False,
         "extract_review": lambda output: output,
-        "display_name": "Cursor",
         "cli_label": "cursor",
         "no_verdict_label": "Cursor",
-        # Prompt-fit: dynamic diff fit + persona override + final argv backstop.
-        "prompt_fit": "cursor_argv",
         "needs_persona_override": True,
     })
     BACKEND_REGISTRY["claude"].update({
@@ -43046,11 +42966,8 @@ def _wire_backend_review_hooks() -> None:
         # Effort is a real CLI axis (--effort), dropped only at the ladder floor.
         "include_effort": True,
         "extract_review": lambda output: output,
-        "display_name": "Claude",
         "cli_label": "claude",
         "no_verdict_label": "Claude",
-        # Prompt-fit: none (stdin delivery; no argv budget).
-        "prompt_fit": "none",
         # ``claude -p`` loads the repo's CLAUDE.md - the same ambient-instruction
         # hazard cursor neutralises with the persona override.
         "needs_persona_override": True,
@@ -43344,7 +43261,7 @@ def _backend_impl_review(args: argparse.Namespace, backend: str) -> None:
     prior_findings = _read_prior_findings(receipt_path)
     prior_items = _read_prior_structured_findings(receipt_path)
     if is_rereview or prior_findings is not None or prior_items is not None:
-        prompt, injected_prompt, _ = _rereview_prompt_pair(
+        prompt, injected_prompt = _rereview_prompt_pair(
             prompt,
             files=get_changed_files(base_branch),
             review_type="implementation",
@@ -43787,17 +43704,14 @@ def _bind_receipt_model_effort(
     prior_receipt_effort: Optional[str],
 ) -> tuple["BackendSpec", Optional[str], Optional[str]]:
     """Apply _receipt_model_effort; codex rebinds the BackendSpec (PR #203 r2)."""
-    if backend == "codex":
-        _rm, _re = _receipt_model_effort(
-            resolved_spec, resolution,
-            prior_model=prior_receipt_model, prior_effort=prior_receipt_effort,
-        )
-        resolved_spec = dataclass_replace(resolved_spec, model=_rm, effort=_re)
-        return resolved_spec, resolved_spec.model, resolved_spec.effort
     effective_model, effective_effort = _receipt_model_effort(
         resolved_spec, resolution,
         prior_model=prior_receipt_model, prior_effort=prior_receipt_effort,
     )
+    if backend == "codex":
+        resolved_spec = dataclass_replace(
+            resolved_spec, model=effective_model, effort=effective_effort,
+        )
     return resolved_spec, effective_model, effective_effort
 
 def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
@@ -43862,7 +43776,7 @@ def _backend_plan_review(args: argparse.Namespace, backend: str) -> None:
     prior_findings = _read_prior_findings(receipt_path)
     prior_items = _read_prior_structured_findings(receipt_path)
     if is_rereview or prior_findings is not None or prior_items is not None:
-        prompt, injected_prompt, _ = _rereview_prompt_pair(
+        prompt, injected_prompt = _rereview_prompt_pair(
             prompt,
             files=spec_files,
             review_type="plan",
@@ -44172,7 +44086,7 @@ def _backend_completion_review(args: argparse.Namespace, backend: str) -> None:
     prior_findings = _read_prior_findings(receipt_path)
     prior_items = _read_prior_structured_findings(receipt_path)
     if is_rereview or prior_findings is not None or prior_items is not None:
-        prompt, injected_prompt, _ = _rereview_prompt_pair(
+        prompt, injected_prompt = _rereview_prompt_pair(
             prompt,
             files=get_changed_files(base_branch),
             review_type="completion",

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "1b324d9a5356e86e9c25bfb3070b2eb995c6b10f2d83137057e99136b632a9c8"
+      "sha256": "472ffad942594833ceb1bfc193c82d20916f492c5566cb02db07c44f530d0e53"
     },
     {
       "path": "flowctl_tracker/__init__.py",
@@ -26,7 +26,7 @@
     },
     {
       "path": "flowctl_tracker/credentials.py",
-      "sha256": "7911099e37d053422aba9327a0169118f0fe5cbd14d54ad846ab865aa0a5a983"
+      "sha256": "b76cab7791e1ee6934affe3ec5739a582121ad9e97f44a59429fccd53b1cea3b"
     },
     {
       "path": "flowctl_tracker/envelope.py",
@@ -34,7 +34,7 @@
     },
     {
       "path": "flowctl_tracker/executor.py",
-      "sha256": "72ac9efe1c8c69f61ef9806b34eaa221196674476a6b8f8df9d0e55e667c4688"
+      "sha256": "5adbb6b1406f24edd03cd94ae2136bafacff5850f10019c3cde14525b2861c9c"
     },
     {
       "path": "flowctl_tracker/facade/__init__.py",
@@ -150,7 +150,7 @@
     },
     {
       "path": "flowctl_tracker/subjects.py",
-      "sha256": "8005754930019097167137ab01fc12ffcdee4bebf150270d12f33c268500fcc9"
+      "sha256": "cd1eca709e2329c852a28b040505f9beec236d1e0ab549d446d23a485c1748ef"
     },
     {
       "path": "flowctl_tracker/syncbody/__init__.py",

--- a/plugins/flow-next/scripts/flowctl_tracker/credentials.py
+++ b/plugins/flow-next/scripts/flowctl_tracker/credentials.py
@@ -63,7 +63,9 @@ def _glab_config_token(host: Optional[str] = None) -> Optional[str]:
 def _basic(user: str, token: str) -> str:
     import base64
 
-    return "Basic " + base64.b64encode(f"{user}:{token}".encode()).decode()
+    encoded = base64.b64encode(f"{user}:{token}".encode()).decode()
+    _remember(encoded)
+    return "Basic " + encoded
 
 
 def resolve(provider: str, *, auth_scheme: Optional[str] = None,

--- a/plugins/flow-next/scripts/flowctl_tracker/executor.py
+++ b/plugins/flow-next/scripts/flowctl_tracker/executor.py
@@ -47,11 +47,6 @@ def _slots_for(cap: Optional[int]) -> threading.BoundedSemaphore:
         return _SLOTS_BY_CAP[cap]
 
 
-def concurrency_slots_available() -> int:
-    """Test seam: how many transports may still start."""
-    return _SLOTS._value  # noqa: SLF001 - deliberate introspection for tests
-
-
 class Executor(Protocol):
     def __call__(self, request: Request) -> Result: ...
 
@@ -279,11 +274,9 @@ def execute(
                             subtype="construction")
     is_cli = isinstance(request.url_or_argv, (list, tuple))
     cred: Optional[Credential] = None
-    if not is_cli:
-        # HTTP route only. `_cli` never consumes the credential - gh/glab carry
-        # their own auth - so resolving here anyway meant a garbage GITLAB_TOKEN
-        # in the environment failed a glab CLI call with auth/resolve even
-        # though the call would have succeeded. Unused state must not gate.
+    if not is_cli and request.credential_policy is CredentialPolicy.PROVIDER_AUTH:
+        # Only authenticated HTTP requests consume provider credentials.
+        # CLI routes authenticate themselves; anonymous requests need no secret.
         try:
             # A corrupt glab config or an unreadable credential source must not
             # escape either - this sits outside every other guard.

--- a/plugins/flow-next/scripts/flowctl_tracker/subjects.py
+++ b/plugins/flow-next/scripts/flowctl_tracker/subjects.py
@@ -17,8 +17,7 @@ import time
 from pathlib import Path
 from typing import Iterator, Optional, Union
 
-from .lifecycle.helpers import (Result, atomic_write_json, default_tracker,
-                                derive_link_state, dict_, leaf_is_safe,
+from .lifecycle.helpers import (Result, atomic_write_json, dict_, leaf_is_safe,
                                 merged_tracker, now_iso)
 from .types import ErrorClass, TrackerError
 
@@ -229,7 +228,17 @@ def _bounded_file_lock(
     """
     from .config_lock import ConfigLockTimeout  # noqa: PLC0415
 
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        invalid_parent = lock_path.parent.is_symlink() or not lock_path.parent.is_dir()
+    except OSError as exc:
+        raise ConfigLockTimeout(
+            f"cannot prepare {label} lock parent {lock_path.parent}: {exc}"
+        ) from exc
+    if invalid_parent:
+        raise ConfigLockTimeout(
+            f"{label} lock parent is not a real directory: {lock_path.parent}"
+        )
     try:
         st = os.lstat(lock_path)
         if not stat_mod.S_ISREG(st.st_mode):
@@ -418,17 +427,6 @@ def subject_collision(
                 details={"owner": sid, "kind": kind, "durable": durable_id},
             )
     return None
-
-
-def ensure_tracker_block(data: dict) -> dict:
-    """Ensure subject data has a tracker block with schema defaults."""
-    raw = dict_(data.get("tracker"))
-    if not raw:
-        raw = default_tracker()
-    data = dict(data)
-    data["tracker"] = {**default_tracker(), **raw}
-    data["tracker"]["linkState"] = derive_link_state(raw)
-    return data
 
 
 def charts_projection_enabled(config: dict) -> bool:

--- a/plugins/flow-next/scripts/lib/opencode_generate.py
+++ b/plugins/flow-next/scripts/lib/opencode_generate.py
@@ -78,8 +78,6 @@ PINNED_PERMISSION_KEYS: frozenset[str] = frozenset(
     }
 )
 
-PERMISSION_ACTIONS: frozenset[str] = frozenset({"allow", "ask", "deny"})
-
 # Canonical frontmatter keys that carry no permission meaning and are dropped.
 # Together with the handled keys below this is a closed allowlist: an unknown
 # canonical key fails generation, because a silently dropped permission-shaped
@@ -220,19 +218,6 @@ def permission_map(tokens: list[str], source: Path) -> dict[str, str]:
                 f"in the pinned PermissionConfig key set",
             )
         out[key] = "deny"
-    for key, action in out.items():
-        if key not in PINNED_PERMISSION_KEYS:
-            raise GenerateError(
-                "UNREPRESENTABLE_DENIAL",
-                f"emitted permission key {key!r} from {source} is not in the "
-                f"pinned PermissionConfig key set",
-            )
-        if action not in PERMISSION_ACTIONS:
-            raise GenerateError(
-                "UNREPRESENTABLE_DENIAL",
-                f"emitted permission action {action!r} for {key!r} from "
-                f"{source} is not allow|ask|deny",
-            )
     return out
 
 

--- a/plugins/flow-next/tests/test_backend_spec.py
+++ b/plugins/flow-next/tests/test_backend_spec.py
@@ -1928,7 +1928,6 @@ class TestBackendReviewDriverHooks(unittest.TestCase):
             "resolve_spec",
             "check_probe",
             "needs_persona_override",
-            "prompt_fit",
             "resume_modes",
             "mint_session_id",
             "include_effort",
@@ -1958,10 +1957,6 @@ class TestBackendReviewDriverHooks(unittest.TestCase):
         self.assertTrue(BACKEND_REGISTRY["codex"]["include_effort"])
         self.assertTrue(BACKEND_REGISTRY["copilot"]["include_effort"])
         self.assertFalse(BACKEND_REGISTRY["cursor"]["include_effort"])
-
-        self.assertEqual(BACKEND_REGISTRY["codex"]["prompt_fit"], "none")
-        self.assertEqual(BACKEND_REGISTRY["copilot"]["prompt_fit"], "none")
-        self.assertEqual(BACKEND_REGISTRY["cursor"]["prompt_fit"], "cursor_argv")
 
         self.assertEqual(
             BACKEND_REGISTRY["codex"]["resume_modes"], (None, "codex")
@@ -2093,10 +2088,8 @@ class TestBackendReviewDriverHooks(unittest.TestCase):
             "has_sandbox": False,
             "include_effort": True,
             "extract_review": lambda output: output,
-            "display_name": "MockReview",
             "cli_label": "mockreview",
             "no_verdict_label": "MockReview",
-            "prompt_fit": "none",
         }
 
         prev_cwd = os.getcwd()

--- a/plugins/flow-next/tests/test_chart_tracker_projection.py
+++ b/plugins/flow-next/tests/test_chart_tracker_projection.py
@@ -1384,6 +1384,25 @@ class ProjectionSerializationTests(unittest.TestCase):
             # No remote work happened without the lock.
             self.assertEqual(results["calls"], [])
 
+    def test_tracker_locks_reject_symlinked_parent_without_external_writes(self) -> None:
+        from flowctl_tracker import subjects as SJ
+        from flowctl_tracker.config_lock import ConfigLockTimeout
+
+        for lock in (SJ.chart_projection_lock, SJ.charts_resource_lock):
+            with self.subTest(lock=lock.__name__), tempfile.TemporaryDirectory() as tmp:
+                flow = Path(tmp) / ".flow"
+                external = Path(tmp) / "external"
+                flow.mkdir()
+                external.mkdir()
+                try:
+                    (flow / "locks").symlink_to(external, target_is_directory=True)
+                except (OSError, NotImplementedError):
+                    self.skipTest("directory symlinks unavailable")
+                with self.assertRaises(ConfigLockTimeout):
+                    with lock(flow):
+                        self.fail("acquired a lock through a symlinked parent")
+                self.assertEqual(list(external.iterdir()), [])
+
 
 # ---------------------------------------------------------------------------
 # Remote read failure aborts the update step

--- a/plugins/flow-next/tests/test_codex_config_merge.py
+++ b/plugins/flow-next/tests/test_codex_config_merge.py
@@ -42,6 +42,16 @@ class ConfigMergeTests(unittest.TestCase):
             self.assertEqual(data['custom']['note'], '\u65e5\u672c')
             self.assertEqual(data['agents']['scout']['description'], 'Unicode \u2192 \u201d')
             self.assertEqual(next(root.glob('config.toml.pre-flow-next-*')).read_bytes(), original_bytes)
+    def test_commented_headers_and_array_tables_preserve_user_settings(self):
+        text = '[features] # user switches\ncodex_hooks = true\n'
+        text += '[custom] # other hooks\nhooks = false\n'
+        text += '[[skills.config]] # disabled skill\npath = "/mine"\nenabled = false\n'
+        result = mod.merge(text, SOURCE, 12)
+        data = tomllib.loads(result)
+        self.assertTrue(data['features']['hooks'])
+        self.assertEqual(data['custom'], {'hooks': False})
+        self.assertEqual(data['skills'], tomllib.loads(text)['skills'])
+        self.assertEqual(mod.merge(result, SOURCE, 12), result)
 
     def test_unmarked_duplicate_recovery_and_scope(self):
         text = '[agents]\nenabled = true\nmax_concurrent_threads_per_session = 12\n' + ROLE

--- a/plugins/flow-next/tests/test_codex_hooks_normalize.py
+++ b/plugins/flow-next/tests/test_codex_hooks_normalize.py
@@ -10,6 +10,7 @@ import importlib.util
 import subprocess
 import sys
 import tempfile
+import tomllib
 import unittest
 from pathlib import Path
 
@@ -60,6 +61,23 @@ def _assert_normal(text: str):
 # unittest-style (fn-111 follow-up): module-level pytest functions were
 # invisible to unittest discover - these tests silently never ran in CI.
 class TestCodexHooksNormalize(unittest.TestCase):
+    def test_commented_features_header_is_normalized_once(self):
+        src = "[features] # user comment\ncodex_hooks = true\nshell_tool = true\n"
+        out = normalize(src)
+        self.assertEqual(tomllib.loads(out)["features"], {"shell_tool": True, "hooks": True})
+        self.assertIn("[features] # user comment\n", out)
+        self.assertEqual(normalize(out), out)
+
+    def test_unrelated_commented_and_array_tables_are_preserved(self):
+        for header in ("[custom] # user comment", "[[custom]]", "[[custom]] # user comment"):
+            with self.subTest(header=header):
+                unrelated = f"{header}\nhooks = false\ncodex_hooks = false\n"
+                out = normalize("[features]\ncodex_hooks = true\n" + unrelated)
+                data = tomllib.loads(out)
+                self.assertTrue(data["features"]["hooks"])
+                self.assertIn(unrelated, out)
+                self.assertEqual(normalize(out), out)
+
     def test_both_keys_dedup_to_one(self):
         """The exact bug: both codex_hooks and hooks present -> single hooks."""
         src = (

--- a/plugins/flow-next/tests/test_config_snapshot.py
+++ b/plugins/flow-next/tests/test_config_snapshot.py
@@ -34,6 +34,7 @@ import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 # fn-139.1: the tracker package sits beside flowctl.py; under a test module
 # sys.path[0] is THIS directory, not scripts/, so it would not import.
@@ -257,6 +258,47 @@ class ConfigSnapshotTestCase(unittest.TestCase):
         self.assertIs(self._get_json(key="memory.enabled")["value"], True)
         self._write_config({"memory": {"enabled": False}})
         self.assertIs(self._get_json(key="memory.enabled")["value"], False)
+
+    def test_config_readers_share_invalid_file_fallback(self) -> None:
+        path = self.tmpdir / ".flow" / "config.json"
+        for content in (None, b"{broken", b"[]", b"null", b"false", b"\xff"):
+            with self.subTest(content=content):
+                if content is not None:
+                    path.write_bytes(content)
+                snapshot = self.flowctl.load_config_snapshot()
+                self.assertIsNone(snapshot.raw)
+                self.assertEqual(snapshot.merged, self.flowctl.get_default_config())
+                self.assertEqual(self.flowctl.load_flow_config(), snapshot.merged)
+                self.assertIs(
+                    self.flowctl._get_config_from_file("memory.enabled"),
+                    self.flowctl._CONFIG_RAW_SENTINEL,
+                )
+
+    def test_raw_probe_preserves_explicit_values_and_nested_absence(self) -> None:
+        self._write_config({"probe": {"null": None, "false": False, "empty": {}}})
+        for key, expected in (("null", None), ("false", False), ("empty", {})):
+            with self.subTest(key=key):
+                self.assertEqual(
+                    self.flowctl._get_config_from_file(f"probe.{key}"), expected
+                )
+                self.assertIs(
+                    self.flowctl._get_config_from_file(f"probe.{key}.missing"),
+                    self.flowctl._CONFIG_RAW_SENTINEL,
+                )
+
+    def test_each_config_reader_resolves_flow_directory_once(self) -> None:
+        self._write_config({"memory": {"enabled": False}})
+        for reader in (
+            self.flowctl.load_flow_config,
+            self.flowctl.load_config_snapshot,
+            lambda: self.flowctl._get_config_from_file("memory.enabled"),
+        ):
+            with self.subTest(reader=reader):
+                with mock.patch.object(
+                    self.flowctl, "get_flow_dir", wraps=self.flowctl.get_flow_dir
+                ) as resolve:
+                    reader()
+                resolve.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/plugins/flow-next/tests/test_cursor_install_verifier.py
+++ b/plugins/flow-next/tests/test_cursor_install_verifier.py
@@ -1,0 +1,90 @@
+"""The CI install verifier must compare complete component payloads."""
+
+import contextlib
+import importlib
+import io
+import json
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "scripts" / "ci"))
+try:
+    verifier = importlib.import_module("verify_cursor_install")
+finally:
+    sys.path.remove(str(ROOT / "scripts" / "ci"))
+
+
+class CursorInstallVerifierTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.source = Path(self.temp.name) / "source"
+        self.dest = Path(self.temp.name) / "installed"
+        for rel in (
+            "skills/example/SKILL.md",
+            "skills/example/templates/helper.py",
+            "commands/example.md",
+            "agents/example.md",
+            "rules/example.mdc",
+        ):
+            path = self.source / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("source content\n", encoding="utf-8")
+        manifest = self.source / ".cursor-plugin/plugin.json"
+        manifest.parent.mkdir()
+        manifest.write_text(json.dumps({key: f"./{key}" for key in verifier.REQUIRED_COMPONENT_KEYS}))
+        shutil.copytree(self.source, self.dest)
+
+    def check(self):
+        output = io.StringIO()
+        with patch.object(verifier, "SRC", self.source), patch(
+            "sys.argv", ["verify_cursor_install.py", "--dest", str(self.dest)]
+        ), contextlib.redirect_stdout(output), contextlib.redirect_stderr(output):
+            code = verifier.main()
+        return code, output.getvalue()
+
+    def test_matching_install_passes(self):
+        code, output = self.check()
+        self.assertEqual(code, 0, output)
+
+    def test_missing_nested_skill_payload_fails(self):
+        (self.dest / "skills/example/templates/helper.py").unlink()
+        code, output = self.check()
+        self.assertEqual(code, 1, output)
+        self.assertIn("example/templates/helper.py", output)
+
+    def test_extra_nested_skill_payload_fails(self):
+        (self.dest / "skills/example/templates/stale.py").write_text("old", encoding="utf-8")
+        code, output = self.check()
+        self.assertEqual(code, 1, output)
+        self.assertIn("example/templates/stale.py", output)
+
+    def test_changed_nested_skill_payload_fails(self):
+        (self.dest / "skills/example/templates/helper.py").write_text("old", encoding="utf-8")
+        code, output = self.check()
+        self.assertEqual(code, 1, output)
+        self.assertIn("example/templates/helper.py", output)
+
+    def test_installer_excluded_source_cruft_is_not_required(self):
+        for rel in (".DS_Store", "loose.pyc", "__pycache__/helper.pyc"):
+            path = self.source / "skills/example" / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(b"ignored")
+        code, output = self.check()
+        self.assertEqual(code, 0, output)
+
+    def test_installer_excluded_payload_is_rejected_at_destination(self):
+        (self.dest / "skills/example/.DS_Store").write_bytes(b"ignored")
+        code, output = self.check()
+        self.assertEqual(code, 1, output)
+        self.assertIn(".DS_Store", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/flow-next/tests/test_plan_review_candidate_measurement.py
+++ b/plugins/flow-next/tests/test_plan_review_candidate_measurement.py
@@ -1,0 +1,70 @@
+"""Route accuracy must reflect measured files, including missing references."""
+
+import importlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class PlanReviewCandidateMeasurementTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        harness = Path(__file__).resolve().parents[3] / "optimization/reached-path"
+        sys.path.insert(0, str(harness))
+        try:
+            cls.candidate = importlib.import_module("plan_review_candidate")
+        finally:
+            sys.path.remove(str(harness))
+
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.repo = Path(temporary.name)
+        candidate = self.candidate
+        paths = [candidate.ROOT, candidate.COMMON]
+        paths.extend(candidate.backend_file(name) for name in candidate.BACKENDS)
+        for path in paths:
+            target = self.repo / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("instruction\n", encoding="utf-8")
+        baseline = self.repo / "optimization/reached-path/fixtures/b1/plan-review"
+        baseline.mkdir(parents=True)
+        for route in candidate.ROUTES:
+            (baseline / f"{route}.json").write_text(
+                json.dumps({"metrics": {"reached_path_chars": 1000}}),
+                encoding="utf-8",
+            )
+
+    def test_complete_routes_can_pass(self):
+        evidence = self.candidate.route_evidence(self.repo)
+        self.assertTrue(all(evidence["accuracy"].values()))
+        self.assertEqual(evidence["ratchet"]["verdict"], "keep")
+
+    def test_missing_root_aborts_measurement(self):
+        root = self.repo / self.candidate.ROOT
+        root.unlink()
+        with self.assertRaises(FileNotFoundError) as raised:
+            self.candidate.route_evidence(self.repo)
+        self.assertEqual(raised.exception.filename, str(root))
+
+    def test_missing_required_reference_discards_smaller_candidate(self):
+        for relative in (
+            self.candidate.COMMON,
+            self.candidate.backend_file("host"),
+        ):
+            with self.subTest(path=relative):
+                target = self.repo / relative
+                original = target.read_text(encoding="utf-8")
+                target.unlink()
+                try:
+                    evidence = self.candidate.route_evidence(self.repo)
+                finally:
+                    target.write_text(original, encoding="utf-8")
+                self.assertTrue(evidence["accuracy"]["every_route_reduced"])
+                self.assertEqual(evidence["ratchet"]["verdict"], "discard")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/flow-next/tests/test_review_convergence_cap.py
+++ b/plugins/flow-next/tests/test_review_convergence_cap.py
@@ -3916,14 +3916,24 @@ class TestRereviewPromptPair(unittest.TestCase):
 
     def test_single_phase_is_byte_identical_to_the_old_behavior(self):
         for review_type in self.REVIEW_TYPES:
-            dispatch, injected, preamble = self._pair(review_type, two_phase=False)
+            dispatch, injected = self._pair(review_type, two_phase=False)
+            preamble = flowctl.build_rereview_preamble(
+                ["a.py"], review_type,
+                prior_findings="Prior finding #1: something",
+                prior_items=_ratchet_prior_container()["items"],
+            )
             self.assertIsNone(injected, review_type)
             self.assertEqual(dispatch, preamble + "BODY", review_type)
             self.assertIn("<prior_findings>", dispatch, review_type)
 
     def test_two_phase_drops_priors_from_the_dispatch_prompt_only(self):
         for review_type in self.REVIEW_TYPES:
-            dispatch, injected, preamble = self._pair(review_type, two_phase=True)
+            dispatch, injected = self._pair(review_type, two_phase=True)
+            preamble = flowctl.build_rereview_preamble(
+                ["a.py"], review_type,
+                prior_findings="Prior finding #1: something",
+                prior_items=_ratchet_prior_container()["items"], resumed=True,
+            )
             self.assertNotIn("<prior_findings>", dispatch, review_type)
             self.assertIn("<prior_findings>", injected, review_type)
             self.assertEqual(dispatch, preamble + "BODY", review_type)
@@ -3932,7 +3942,7 @@ class TestRereviewPromptPair(unittest.TestCase):
 
     def test_two_phase_keeps_the_machine_read_grammar_in_every_review_type(self):
         for review_type in self.REVIEW_TYPES:
-            dispatch, _injected, _preamble = self._pair(review_type, two_phase=True)
+            dispatch, _injected = self._pair(review_type, two_phase=True)
             self.assertRegex(
                 dispatch,
                 r"(?m)^\s*Prior finding #\d+: (?:fixed|not-fixed|withdrawn)\s*$",

--- a/plugins/flow-next/tests/test_run_tests_parallel.py
+++ b/plugins/flow-next/tests/test_run_tests_parallel.py
@@ -597,11 +597,28 @@ class ProcessTreeCleanupTest(unittest.TestCase):
         matters most).
         """
         self._write_corpus(GRANDCHILD_HOLDS_STDOUT)
+        real_popen = self.mod.subprocess.Popen
+
+        def launch_shard(*args, **kwargs):
+            proc = real_popen(*args, **kwargs)
+
+            def reap_shard():
+                if proc.poll() is None:
+                    proc.kill()
+                proc.wait(timeout=30)
+
+            # This test disables the runner's kill; own its parent as well as
+            # the grandchild, including when an assertion or the runner fails.
+            self.addCleanup(reap_shard)
+            return proc
+
         with mock.patch.object(
             self.mod._ShardTree,
             "terminate",
             lambda _self: "process-tree: kill suppressed (test)",
-        ), mock.patch.object(self.mod, "POST_KILL_COLLECT_S", 2):
+        ), mock.patch.object(self.mod, "POST_KILL_COLLECT_S", 2), mock.patch.object(
+            self.mod.subprocess, "Popen", side_effect=launch_shard
+        ):
             rc, out, wall = self._run()
         self.assertEqual(rc, 1, out)
         self.assertIn("output collection: ABANDONED after 2s", out)

--- a/plugins/flow-next/tests/test_start_reclaim.py
+++ b/plugins/flow-next/tests/test_start_reclaim.py
@@ -155,6 +155,16 @@ class StartReclaimTest(unittest.TestCase):
         self.assertEqual(state["assignee"], "me")
         self.assertEqual(state["claim_note"], TAKEOVER_NOTE)
 
+    def test_force_with_explicit_note_still_transfers_claim(self) -> None:
+        task = self._claimed_task()
+        previous_claimed_at = self._state(task)["claimed_at"]
+        proc = self._run("start", task, "--force", "--note", "handoff", actor="me")
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        state = self._state(task)
+        self.assertEqual(state["assignee"], "me")
+        self.assertNotEqual(state["claimed_at"], previous_claimed_at)
+        self.assertEqual(state["claim_note"], "handoff")
+
     def test_claimed_by_other_without_flags_still_refuses(self) -> None:
         task = self._claimed_task()
         proc = self._run("start", task, actor="me")

--- a/plugins/flow-next/tests/test_tracker_executor.py
+++ b/plugins/flow-next/tests/test_tracker_executor.py
@@ -116,6 +116,20 @@ class Credentials(unittest.TestCase):
         with mock.patch.dict(os.environ, {"GITLAB_TOKEN": "glpat-abcdefghijkl"}):
             self.assertNotIn("glpat-abcdefghijkl", CR.redact("failed: glpat-abcdefghijkl"))
 
+    def test_jira_basic_credential_is_redacted_after_environment_changes(self) -> None:
+        with mock.patch.object(CR, "_SEEN", set()):
+            with mock.patch.dict(os.environ, {
+                "JIRA_EMAIL": "fake@example.test",
+                "JIRA_API_TOKEN": "test-only-token-12345678",
+            }):
+                headers = {}
+                CR.resolve("jira", auth_scheme="cloud-basic").attach(headers)
+            authorization = headers["Authorization"]
+            encoded = authorization.removeprefix("Basic ")
+            self.assertEqual(CR.redact(f"echo: {authorization}"),
+                             "echo: Basic <redacted>")
+            self.assertEqual(CR.redact(encoded), "<redacted>")
+
 
 class CredentialPolicyHonoured(unittest.TestCase):
     """The presigned case: an always-inject executor leaks the key to the asset host."""
@@ -150,6 +164,25 @@ class CredentialPolicyHonoured(unittest.TestCase):
         seen = self._capture(CredentialPolicy.PROVIDER_AUTH)
         joined = " ".join(f"{k}:{v}" for k, v in seen.items())
         self.assertIn("lin_secret_value_1234", joined)
+
+    def test_anonymous_requests_do_not_resolve_provider_credentials(self) -> None:
+        for policy in (CredentialPolicy.PRESIGNED_ANONYMOUS, CredentialPolicy.NONE):
+            with self.subTest(policy=policy), \
+                 mock.patch.object(X, "resolve", side_effect=ValueError("unavailable")) as resolve:
+                request = Request(provider="linear", op="upload", method="PUT",
+                                  url_or_argv="https://uploads.example.com/x",
+                                  credential_policy=policy)
+                response = mock.MagicMock()
+                response.__enter__.return_value = response
+                response.status, response.headers = 200, {}
+                response.read.return_value = b"{}"
+                with mock.patch("urllib.request.OpenerDirector.open", return_value=response) as send:
+                    result = X.execute(request)
+                self.assertIsInstance(result, Response)
+                resolve.assert_not_called()
+                sent = send.call_args.args[0]
+                self.assertFalse({"authorization", "private-token", "x-api-key"}
+                                 & {name.lower() for name, _ in sent.header_items()})
 
 
 class Bounds(unittest.TestCase):

--- a/scripts/ci/verify_cursor_install.py
+++ b/scripts/ci/verify_cursor_install.py
@@ -37,32 +37,13 @@ SRC = REPO_ROOT / "plugins" / "flow-next"
 REQUIRED_COMPONENT_KEYS = ("skills", "agents", "commands", "rules")
 
 
-def _skill_dirs(root: Path) -> set[str]:
-    base = root / "skills"
-    if not base.is_dir():
-        return set()
-    return {p.name for p in base.iterdir() if p.is_dir() and (p / "SKILL.md").is_file()}
-
-
-def _command_files(root: Path) -> set[str]:
-    base = root / "commands"
-    if not base.is_dir():
-        return set()
-    return {p.name for p in base.glob("*.md")}
-
-
-def _agent_files(root: Path) -> set[str]:
-    base = root / "agents"
-    if not base.is_dir():
-        return set()
-    return {p.name for p in base.glob("*.md")}
-
-
-def _rule_files(root: Path) -> set[str]:
-    base = root / "rules"
-    if not base.is_dir():
-        return set()
-    return {p.name for p in base.glob("*.mdc")}
+def _component_files(root: Path, component: str) -> dict[str, bytes]:
+    base = root / component
+    return {
+        path.relative_to(base).as_posix(): path.read_bytes()
+        for path in sorted(base.rglob("*"))
+        if path.is_file()
+    }
 
 
 def _check_manifest(dest: Path, errors: list[str]) -> None:
@@ -104,45 +85,29 @@ def main() -> int:
     # Manifest present + explicit component paths.
     _check_manifest(dest, errors)
 
-    # Completeness: dest must match source 1:1 for the copied component trees.
-    for label, fn in (
-        ("skills", _skill_dirs),
-        ("commands", _command_files),
-        ("agents", _agent_files),
-        ("rules", _rule_files),
-    ):
-        src_set, dst_set = fn(SRC), fn(dest)
-        if not src_set:
+    # Compare every payload file, including nested skill references/templates.
+    file_count = 0
+    for label in REQUIRED_COMPONENT_KEYS:
+        source = {
+            rel: content for rel, content in _component_files(SRC, label).items()
+            if "__pycache__" not in Path(rel).parts
+            and not rel.endswith(".pyc") and Path(rel).name != ".DS_Store"
+        }
+        installed = _component_files(dest, label)
+        file_count += len(installed)
+        if not source:
             errors.append(f"source has no {label} — cannot verify (check SRC path)")
             continue
-        missing = src_set - dst_set
-        extra = dst_set - src_set
+        missing = source.keys() - installed.keys()
+        extra = installed.keys() - source.keys()
         if missing:
             errors.append(f"{label}: {len(missing)} missing in install: {sorted(missing)[:5]}")
         if extra:
             errors.append(f"{label}: {len(extra)} unexpected in install: {sorted(extra)[:5]}")
-
-    # Content integrity: same names is not enough — stale/empty/corrupted
-    # copies with matching names must fail (fn-123 review hardening). Compare
-    # content hashes for every file under the copied component trees.
-    import hashlib
-
-    def _tree_hashes(root: Path, sub: str) -> dict[str, str]:
-        base = root / sub
-        if not base.is_dir():
-            return {}
-        return {
-            str(p.relative_to(base)): hashlib.sha256(p.read_bytes()).hexdigest()
-            for p in sorted(base.rglob("*"))
-            if p.is_file()
-        }
-
-    for sub in ("skills", "commands", "agents", "rules"):
-        src_h, dst_h = _tree_hashes(SRC, sub), _tree_hashes(dest, sub)
-        stale = [rel for rel, h in src_h.items() if rel in dst_h and dst_h[rel] != h]
+        stale = [rel for rel, content in source.items() if rel in installed and installed[rel] != content]
         if stale:
             errors.append(
-                f"{sub}: {len(stale)} file(s) differ from source (stale install?"
+                f"{label}: {len(stale)} file(s) differ from source (stale install?"
                 f" re-run installer): {stale[:5]}"
             )
 
@@ -163,10 +128,7 @@ def main() -> int:
 
     print(
         f"OK: Cursor install verified at {dest}\n"
-        f"    skills={len(_skill_dirs(dest))} "
-        f"commands={len(_command_files(dest))} "
-        f"agents={len(_agent_files(dest))} "
-        f"rules={len(_rule_files(dest))}; "
+        f"    component files={file_count}; "
         f"excludes honored (no codex/ tests/ *.pyc)."
     )
     return 0

--- a/scripts/normalize_codex_hooks.py
+++ b/scripts/normalize_codex_hooks.py
@@ -30,7 +30,7 @@ import sys
 
 _HOOKS_LINE = "hooks = true  # flow-next"
 # A section header like `[features]` or `[agents.foo]`. Leading whitespace tolerated.
-_SECTION_RE = re.compile(r"^\s*\[([^\]]+)\]\s*$")
+_SECTION_RE = re.compile(r"^\s*\[(\[?[^\]]+\]?)\]\s*(?:#.*)?$")
 _CODEX_HOOKS_RE = re.compile(r"^\s*codex_hooks\s*=")
 _HOOKS_RE = re.compile(r"^\s*hooks\s*=")
 
@@ -83,11 +83,7 @@ def normalize(text: str) -> str:
         out.append("[features]")
         out.append(_HOOKS_LINE)
 
-    result = "\n".join(out)
-    # Preserve a single trailing newline if the original had one (or add it).
-    if text.endswith("\n") or not text.endswith("\n"):
-        result = result.rstrip("\n") + "\n"
-    return result
+    return "\n".join(out).rstrip("\n") + "\n"
 
 
 def main(argv: list[str]) -> int:


### PR DESCRIPTION
# refactor(python): remove dead paths and fix exposed regressions

I removed unused Python machinery and fixed defects exposed by the review.

> Spec [fn-224-refactorpython-remove-dead-paths-and](https://github.com/gmickel/flow-next/blob/ff52732aef4ecf228712c51a757b17f02c75b7d3/.flow/specs/fn-224-refactorpython-remove-dead-paths-and.md) · `refactor/python-slop-review` → `main` · 1/1 task done · R1-R4 evidenced.

## TL;DR

- Five GPT-6 Astra subagents reviewed the Python code. The changes delete unused abstractions, registry fields, helpers, and repeated checks; production Python is 141 lines smaller.
- Fixed forced takeover with custom notes, anonymous tracker credential handling, Basic credential redaction, lock-directory containment, TOML boundaries, and incomplete verification.
- The full suite passed 4,806 tests with 7 skips. After a fixture-only cleanup, all 30 affected runner tests passed again; Ruff is green. Skill prose and emitted review prompts are unchanged.

## Not in this PR (by design)

- Skill prose and prompt optimization.
- New CLI commands, dependencies, configuration flags, or architectural extraction.
- Rewriting historical evaluation results or implementing unrelated backlog specs.
- Releases, merges, and live tracker mutations.

## The change, top to bottom

Removed dead Python paths and fixed ownership, credential, TOML, and verification failures.

| Proof | Value | Sources |
|---|---|---|
| Artifact | `python-review-ff52732a-v2` | artifact identity |
| Base commit | `32f73742251dafd76e9799d6893518778c4e9408` | artifact currentness |
| Head commit | `ff52732aef4ecf228712c51a757b17f02c75b7d3` | artifact identity |
| Human-review lines | 676 | deterministic file stats |
| Canonical files | 20 | deterministic membership |
| Total files | 25 | deterministic membership |
| Full suite | 4806 tests across 207 files; zero failures/errors; 7 skips. | source:task |
| Final fixture edit | 30 affected runner tests passed afterward; no orphan test shards remained. | source:task |
| Other gates | Repository Ruff passed; distribution regenerated; two Codex sync runs were identical. | source:task |
| Coverage | R1-R4 evidenced by the completed task. | source:task, source:r1, source:r2, source:r3, source:r4 |
| Review limits | Five Astra subagents plus peer review; no cross-family gate or live backend evaluation recorded. | source:task |

**Legend:** `WHY` `PRINCIPLE` `STEP` `KEPT` `VERIFY` · `NEW` `MODIFIED` `DELETED` `RENAMED` `COPIED` · `CANONICAL` `GENERATED` `MECHANICAL`

<details open>
<summary><code>STEP</code> 1. Simplify CLI state and review dispatch — Remove zero-consumer abstractions and repeated logic while repairing forced task takeover.</summary>

Evidence: source:task, source:diff, task:fn-224-refactorpython-remove-dead-paths-and.1

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/scripts/flowctl.py` | Delete dead storage/parser/registry code, share config reads, and preserve ownership transfer with custom notes. | +44/-130 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-a52f4f2101d1a9031615badb0a45084834516bcb0b6ec993a50076403226568d) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_backend_spec.py` | Remove assertions for unused registry fields. | +0/-7 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-6855b53451682918286e505a37cffe64ab47eb48c87a99aa0c33c63e81665ad3) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_config_snapshot.py` | Cover invalid-file fallback, raw explicit values, and one directory resolution. | +42/-0 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-9f80d22bae94c5b5ae9c27935559178cb62b1575d59f92e585094685b9a5f8fd) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_review_convergence_cap.py` | Retain exact dispatch-byte and resume checks for the two-result helper. | +13/-3 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-5eff4a0f3e63224ae9dc4b4f552c511a9c24224afefcdc1b652138677703e282) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_start_reclaim.py` | Regress forced ownership transfer with a custom note. | +10/-0 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-f0e5bb747e4805c15bde0a7f4df177137e1ee348d485663b1e7d18ea9506f43b) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |

</details>

<details>
<summary><code>STEP</code> 2. Honor tracker authentication and lock boundaries — Anonymous requests bypass credentials; encoded secrets are scrubbed; chart locks reject symlinked parents.</summary>

Evidence: source:task, source:diff, task:fn-224-refactorpython-remove-dead-paths-and.1

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/scripts/flowctl_tracker/credentials.py` | Redact the encoded Jira Basic credential sent on requests. | +3/-1 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-72143c8afa46c86c3ff59ff1fe392a7b0540ad26a57c23d348fdfddd0e2d87d2) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/scripts/flowctl_tracker/executor.py` | Skip unused credential resolution for anonymous HTTP; delete unused concurrency accessor. | +3/-10 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-384955e5e28458db187e39dd430602769c7352933e9cf3ac21a696abeafec8f2) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/scripts/flowctl_tracker/subjects.py` | Reject symlinked lock parents and remove an unused tracker-block helper. | +12/-14 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-4dede70c2fa5899d72565ee870395a1dff9e3c50f2fef39b05eb26ea919e1132) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_chart_tracker_projection.py` | Exercise both tracker locks through a symlinked directory. | +19/-0 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-65283d8586c7c7fc0933dedada4b17a2ce0b90415aed4225952bb1a3977c48b9) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_tracker_executor.py` | Regress anonymous credential bypass and encoded Basic redaction. | +33/-0 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-af34d0f5b30dbb7a80f44a5d6ed179db15dab2604488f64623133569ccbe8a26) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |

</details>

<details>
<summary><code>STEP</code> 3. Simplify installer tooling — Preserve unrelated TOML and compare every installed payload file; retain actual OpenCode permission enforcement.</summary>

Evidence: source:task, source:diff, task:fn-224-refactorpython-remove-dead-paths-and.1

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/scripts/lib/opencode_generate.py` | Delete repeated validation after keys were checked and actions fixed to deny. | +0/-15 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-f7599548719ed14e85361bc710a974c2d61223799207432cbddde12fab460b95) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_codex_config_merge.py` | Verify commented feature headers preserve unrelated TOML during merge. | +11/-0 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-59d7a3a2c0ad15d91fbc8d4b0959707e8264bac54331704f179eb100e321afc9) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_codex_hooks_normalize.py` | Cover commented table headers, array boundaries, preservation, and idempotency. | +18/-0 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-0d57ae7f2ca39629c7b41c1b795b07f3a4f0982df10e5757594b814a07b58295) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `NEW` | `CANONICAL` | `plugins/flow-next/tests/test_cursor_install_verifier.py` | Exercise complete, missing, extra, changed, and excluded installation files. | +90/-0 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-6f226a5a3bb96fd7d1f175a59f78c97be69af1d67ababcfed1ade47f876ce358) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `MODIFIED` | `CANONICAL` | `scripts/ci/verify_cursor_install.py` | Compare complete component payloads once, including missing, extra, and changed nested files. | +23/-61 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-2a92f92d81b7902b1b129bd47a57282028b3ce4f8fa3fceefe7d6b084282485b) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `MODIFIED` | `CANONICAL` | `scripts/normalize_codex_hooks.py` | Preserve commented TOML table and array boundaries; remove tautological newline handling. | +2/-6 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-9a827c4f5a33e8df5265fa75121548ffcf4585d72eb32d81e481ffa3d161e02b) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |

</details>

<details>
<summary><code>STEP</code> 4. Make verification evidence reliable — Missing required evaluation files cannot pass, and the timeout fixture cleans up its deliberately surviving parent.</summary>

Evidence: source:task, source:diff, task:fn-224-refactorpython-remove-dead-paths-and.1

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `optimization/reached-path/plan_review_candidate.py` | Derive route accuracy from measured files instead of declared reads. | +12/-3 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-eb20bef0afe967ea33d3d9dbbfd34f7f842e64957fc3f2f9864cc793a1a91006) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `NEW` | `CANONICAL` | `plugins/flow-next/tests/test_plan_review_candidate_measurement.py` | Reject missing references and missing root while accepting complete routes. | +70/-0 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-9b8a3a7a001749ad3da22915245a8509953e049331967e6ea4e4136a6fefa7f5) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `MODIFIED` | `CANONICAL` | `plugins/flow-next/tests/test_run_tests_parallel.py` | Reap the parent shard when the test intentionally suppresses process killing. | +18/-1 | [diff](https://github.com/gmickel/flow-next/commit/8193465f791a0e9862d0c9e72ee8e8e9ad498ea8#diff-522079381a89133c3d3f98439a36a59d482c7703db95dc078369582a3ee456ef) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |

</details>

<details>
<summary><code>STEP</code> 5. Record the review and regenerate distribution hashes — Keep accepted/rejected findings and test evidence in Flow; record fixes for the next release.</summary>

Evidence: source:task, source:diff, task:fn-224-refactorpython-remove-dead-paths-and.1

<details>
<summary>Generated/mechanical files (4)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `COPIED` | `MECHANICAL` | `.flow/specs/fn-224-refactorpython-remove-dead-paths-and.json` | Record Python review requirements and boundaries. | +6/-6 | [diff](https://github.com/gmickel/flow-next/blob/ff52732aef4ecf228712c51a757b17f02c75b7d3/.flow/specs/fn-224-refactorpython-remove-dead-paths-and.json) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `NEW` | `MECHANICAL` | `.flow/specs/fn-224-refactorpython-remove-dead-paths-and.md` | Record Python review requirements and boundaries. | +37/-0 | [diff](https://github.com/gmickel/flow-next/blob/ff52732aef4ecf228712c51a757b17f02c75b7d3/.flow/specs/fn-224-refactorpython-remove-dead-paths-and.md) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `NEW` | `MECHANICAL` | `.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.json` | Record review scope, disposition, and regression evidence. | +14/-0 | [diff](https://github.com/gmickel/flow-next/blob/ff52732aef4ecf228712c51a757b17f02c75b7d3/.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.json) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |
| `NEW` | `MECHANICAL` | `.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.md` | Record review scope, disposition, and regression evidence. | +51/-0 | [diff](https://github.com/gmickel/flow-next/blob/ff52732aef4ecf228712c51a757b17f02c75b7d3/.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.md) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |

</details>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `CANONICAL` | `CHANGELOG.md` | Record behavior fixes under Unreleased; preserve the release version. | +2/-0 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |

<details>
<summary>Generated/mechanical files (1)</summary>

| Change | Attention | File | Purpose | +/- | Diff | Evidence |
|---|---|---|---|---:|---|---|
| `MODIFIED` | `GENERATED` | `plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json` | Regenerated distribution integrity hashes. | +4/-4 | [diff](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-e933177e059d7c184bbc394bad0757e4058a6ebc899d3dcd529b1a965b1a7d29) | source:diff, source:task, task:fn-224-refactorpython-remove-dead-paths-and.1 |

</details>

</details>

## Critical changes

- [plugins/flow-next/scripts/flowctl.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-a52f4f2101d1a9031615badb0a45084834516bcb0b6ec993a50076403226568d) has +44/-130 lines.
- [plugins/flow-next/tests/test_cursor_install_verifier.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-6f226a5a3bb96fd7d1f175a59f78c97be69af1d67ababcfed1ade47f876ce358) has +90/-0 lines.
- [scripts/ci/verify_cursor_install.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-2a92f92d81b7902b1b129bd47a57282028b3ce4f8fa3fceefe7d6b084282485b) has +23/-61 lines.
- [plugins/flow-next/tests/test_plan_review_candidate_measurement.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-9b8a3a7a001749ad3da22915245a8509953e049331967e6ea4e4136a6fefa7f5) has +70/-0 lines.
- [.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.md](https://github.com/gmickel/flow-next/blob/ff52732aef4ecf228712c51a757b17f02c75b7d3/.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.md) has +51/-0 lines; task evidence, included in the skim bucket.
- [plugins/flow-next/scripts/flowctl_tracker/credentials.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-72143c8afa46c86c3ff59ff1fe392a7b0540ad26a57c23d348fdfddd0e2d87d2) changes credential redaction and is the export's security-sensitive path.

## How to review this PR

The walkthrough records the full suite, the subsequent 30-test rerun, Ruff, and generation checks. R1-R4 are evidenced. Astra peer review ran; no cross-family review gate or live backend evaluation is recorded.

Start with the two files below, then sample the regression cases and deliberate deletions. The task record includes the rejected cleanup candidates and their reasons.

## Review plan

### Must review (~25%)

- [ ] [plugins/flow-next/scripts/flowctl.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-a52f4f2101d1a9031615badb0a45084834516bcb0b6ec993a50076403226568d) carries the largest code change. Do config fallback and raw-value semantics survive, and does ownership transfer happen independently of custom notes? Open `load_flow_config`, `cmd_start`, and the review-dispatch changes.
- [ ] [plugins/flow-next/scripts/flowctl_tracker/credentials.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-72143c8afa46c86c3ff59ff1fe392a7b0540ad26a57c23d348fdfddd0e2d87d2) changes a security-sensitive path. Does the encoded credential enter redaction before any response or error can echo it? Open `_basic`.

### Spot-check

- [ ] [CHANGELOG.md](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed).
- [ ] [optimization/reached-path/plan_review_candidate.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-eb20bef0afe967ea33d3d9dbbfd34f7f842e64957fc3f2f9864cc793a1a91006).
- [ ] [plugins/flow-next/scripts/flowctl_tracker/executor.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-384955e5e28458db187e39dd430602769c7352933e9cf3ac21a696abeafec8f2).
- [ ] [plugins/flow-next/scripts/flowctl_tracker/subjects.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-4dede70c2fa5899d72565ee870395a1dff9e3c50f2fef39b05eb26ea919e1132).
- [ ] [plugins/flow-next/scripts/lib/opencode_generate.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-f7599548719ed14e85361bc710a974c2d61223799207432cbddde12fab460b95).
- [ ] [plugins/flow-next/tests/test_backend_spec.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-6855b53451682918286e505a37cffe64ab47eb48c87a99aa0c33c63e81665ad3).
- [ ] [plugins/flow-next/tests/test_chart_tracker_projection.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-65283d8586c7c7fc0933dedada4b17a2ce0b90415aed4225952bb1a3977c48b9).
- [ ] [plugins/flow-next/tests/test_codex_config_merge.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-59d7a3a2c0ad15d91fbc8d4b0959707e8264bac54331704f179eb100e321afc9).
- [ ] [plugins/flow-next/tests/test_codex_hooks_normalize.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-0d57ae7f2ca39629c7b41c1b795b07f3a4f0982df10e5757594b814a07b58295).
- [ ] [plugins/flow-next/tests/test_config_snapshot.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-9f80d22bae94c5b5ae9c27935559178cb62b1575d59f92e585094685b9a5f8fd).
- [ ] [plugins/flow-next/tests/test_cursor_install_verifier.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-6f226a5a3bb96fd7d1f175a59f78c97be69af1d67ababcfed1ade47f876ce358).
- [ ] [plugins/flow-next/tests/test_plan_review_candidate_measurement.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-9b8a3a7a001749ad3da22915245a8509953e049331967e6ea4e4136a6fefa7f5).
- [ ] [plugins/flow-next/tests/test_review_convergence_cap.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-5eff4a0f3e63224ae9dc4b4f552c511a9c24224afefcdc1b652138677703e282).
- [ ] [plugins/flow-next/tests/test_run_tests_parallel.py](https://github.com/gmickel/flow-next/commit/8193465f791a0e9862d0c9e72ee8e8e9ad498ea8#diff-522079381a89133c3d3f98439a36a59d482c7703db95dc078369582a3ee456ef).
- [ ] [plugins/flow-next/tests/test_start_reclaim.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-f0e5bb747e4805c15bde0a7f4df177137e1ee348d485663b1e7d18ea9506f43b).
- [ ] [plugins/flow-next/tests/test_tracker_executor.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-af34d0f5b30dbb7a80f44a5d6ed179db15dab2604488f64623133569ccbe8a26).
- [ ] [scripts/ci/verify_cursor_install.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-2a92f92d81b7902b1b129bd47a57282028b3ce4f8fa3fceefe7d6b084282485b).
- [ ] [scripts/normalize_codex_hooks.py](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-9a827c4f5a33e8df5265fa75121548ffcf4585d72eb32d81e481ffa3d161e02b).

### Safe to skim (~15%)

- [ ] [.flow/specs/fn-224-refactorpython-remove-dead-paths-and.json](https://github.com/gmickel/flow-next/blob/ff52732aef4ecf228712c51a757b17f02c75b7d3/.flow/specs/fn-224-refactorpython-remove-dead-paths-and.json). Flow spec/task state and evidence.
- [ ] [.flow/specs/fn-224-refactorpython-remove-dead-paths-and.md](https://github.com/gmickel/flow-next/blob/ff52732aef4ecf228712c51a757b17f02c75b7d3/.flow/specs/fn-224-refactorpython-remove-dead-paths-and.md). Flow spec/task state and evidence.
- [ ] [.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.json](https://github.com/gmickel/flow-next/blob/ff52732aef4ecf228712c51a757b17f02c75b7d3/.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.json). Flow spec/task state and evidence.
- [ ] [.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.md](https://github.com/gmickel/flow-next/blob/ff52732aef4ecf228712c51a757b17f02c75b7d3/.flow/tasks/fn-224-refactorpython-remove-dead-paths-and.1.md). Flow spec/task state and evidence.
- [ ] [plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json](https://github.com/gmickel/flow-next/commit/b2969ec2b5385a3ee7c1896a7ecd6b99f118899f#diff-e933177e059d7c184bbc394bad0757e4058a6ebc899d3dcd529b1a965b1a7d29). Generated integrity hashes, verified after regeneration.

## Memory left behind

The export surfaced these pre-existing notes from the same date; they were already on the base branch. This review wrote no new memory entries.

- `bug/integration/backend-special-case-in-a-shared-helper-2026-09-05`: Adding the `flowctl claude` review subcommands (fn-221.2), the primary commands rejected a foreign `--spec` through `_resolve_claude_review_spec`, but `validate` and `deep-pass` route through the shared `_resolve_session_pass_spec`, whose…
- `bug/integration/cross-family-review-claims-key-on-the-2026-09-05`: Documenting the `claude` review backend (fn-221.4), every overview passage called the review "cross-family" from Codex, Cursor, Grok Build, Droid and OpenCode and "same-family" from Claude Code - keyed on the host name.
- `bug/integration/headless-review-backend-error-envelope-2026-09-05`: Adding the `claude -p` review backend (fn-221.1), the runner shared cursor's lenient result parser and returned an error envelope's `result` text as reviewer output with only the exit code flipped to 1.

Version unchanged; behavior fixes are recorded under Unreleased.

---
Generated by $flow-next-make-pr from fn-224-refactorpython-remove-dead-paths-and against origin/main.
<!-- flow-next:make-pr spec=fn-224-refactorpython-remove-dead-paths-and base=origin/main -->
