### PR TITLE
fix(qa): preserve coverage JSON and release 4.18.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "flow-next",
-      "version": "4.18.0",
+      "version": "4.18.1",
       "source": {
         "source": "local",
         "path": "./plugins/flow-next"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Ships flow-next: zero-dep, spec-driven, Ralph autonomous mode.",
-    "version": "4.18.0"
+    "version": "4.18.1"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency, spec-driven agentic SDLC: durable specs, context-fit plans, re-anchored workers, adversarial cross-model review, and receipts. Includes 20 subagents, 28 commands, 32 skills.",
-      "version": "4.18.0",
+      "version": "4.18.1",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the flow-next.
 
 ## Unreleased
 
+### Fixed
+
+- QA passes now preserve populated requirement coverage when writing their verdict receipt, instead of failing with a JSON parsing error. Empty or unset coverage still defaults to an empty object.
+
 ## [flow-next 4.18.0] - 2026-09-10
 
 Developers can hand a ready, cohesive spec to one capable coding agent and keep the full acceptance contract through implementation and verification. Separate task planning remains available when dependencies, ownership, staged delivery or execution constraints benefit from decomposition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the flow-next.
 
 ## Unreleased
 
+## [flow-next 4.18.1] - 2026-09-10
+
 ### Fixed
 
 - QA passes now preserve populated requirement coverage when writing their verdict receipt, instead of failing with a JSON parsing error. Empty or unset coverage still defaults to an empty object.

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "4.18.0",
+  "version": "4.18.1",
   "description": "Zero-dependency, spec-driven agentic SDLC: durable specs, context-fit plans, re-anchored workers, adversarial cross-model review, and receipts. Includes 20 subagents, 28 commands, 32 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "4.18.0",
+  "version": "4.18.1",
   "description": "Zero-dependency, spec-driven agentic SDLC: durable specs, context-fit plans, re-anchored workers, adversarial cross-model review, and receipts. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.cursor-plugin/plugin.json
+++ b/plugins/flow-next/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "4.18.0",
+  "version": "4.18.1",
   "description": "Zero-dependency, spec-driven agentic SDLC: durable specs, context-fit plans, re-anchored workers, adversarial cross-model review, and receipts. (Ralph autonomous mode is available on other hosts; intentionally not registered on Cursor.)",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/codex/skills/flow-next-qa/workflow.md
+++ b/plugins/flow-next/codex/skills/flow-next-qa/workflow.md
@@ -558,7 +558,7 @@ BRANCH="$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || echo "")"
 export QA_TYPE="qa_verdict" QA_ID="$SPEC_ID" QA_MODE="$MODE" QA_VERDICT="$VERDICT" \
        QA_OUTCOME HEAD_SHA BRANCH \
        QA_FINDINGS="${QA_FINDINGS:-[]}" OPEN_P0P1="${OPEN_P0P1:-[]}" \
-       RID_COVERAGE="${RID_COVERAGE:-{}}" \
+       RID_COVERAGE="${RID_COVERAGE:-}" \
        BLOCKED_REASON="${BLOCKED_REASON:-}" NA_REASON="${NA_REASON:-}"
 
 # Resolve Python 3.11+ once (functionality/version probe — the Windows Store python3

--- a/plugins/flow-next/skills/flow-next-qa/workflow.md
+++ b/plugins/flow-next/skills/flow-next-qa/workflow.md
@@ -556,7 +556,7 @@ BRANCH="$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || echo "")"
 export QA_TYPE="qa_verdict" QA_ID="$SPEC_ID" QA_MODE="$MODE" QA_VERDICT="$VERDICT" \
        QA_OUTCOME HEAD_SHA BRANCH \
        QA_FINDINGS="${QA_FINDINGS:-[]}" OPEN_P0P1="${OPEN_P0P1:-[]}" \
-       RID_COVERAGE="${RID_COVERAGE:-{}}" \
+       RID_COVERAGE="${RID_COVERAGE:-}" \
        BLOCKED_REASON="${BLOCKED_REASON:-}" NA_REASON="${NA_REASON:-}"
 
 # Resolve Python 3.11+ once (functionality/version probe — the Windows Store python3

--- a/plugins/flow-next/tests/test_qa_writer_shell.py
+++ b/plugins/flow-next/tests/test_qa_writer_shell.py
@@ -1,0 +1,59 @@
+"""Execute the shipped QA receipt writer through its real shell/CLI boundary."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+PLUGIN = Path(__file__).resolve().parents[1]
+WORKFLOWS = [
+    PLUGIN / 'skills/flow-next-qa/workflow.md',
+    PLUGIN / 'codex/skills/flow-next-qa/workflow.md',
+]
+SHELLS = [shell for name in ('bash', 'zsh') if (shell := shutil.which(name))]
+
+
+@unittest.skipIf(os.name == 'nt' or not SHELLS, 'requires a POSIX shell')
+class QaWriterShellTest(unittest.TestCase):
+    def test_coverage_survives_the_actual_receipt_writer(self):
+        coverage = {'covered': 1, 'total': 1, 'rids': [{'id': 'R1', 'coverage': 'live'}]}
+        for workflow in WORKFLOWS:
+            section = workflow.read_text().split('### 6.3 —', 1)[1]
+            block = section.split('```bash\n', 1)[1].split('\n```', 1)[0]
+            for shell in SHELLS:
+                for value in (None, '', json.dumps(coverage)):
+                    with self.subTest(workflow=workflow, shell=shell, value=value):
+                        with tempfile.TemporaryDirectory() as tmp:
+                            root = Path(tmp)
+                            subprocess.run(['git', 'init', '-q'], cwd=root, check=True)
+                            subprocess.run(['git', '-c', 'user.name=QA test', '-c', 'user.email=qa@example.test',
+                                            '-c', 'commit.gpgsign=false', '-c', 'core.hooksPath=/dev/null',
+                                            'commit', '--allow-empty', '-qm', 'baseline'], cwd=root, check=True)
+                            env = dict(os.environ)
+                            for key in ('RID_COVERAGE', 'REVIEW_RECEIPT_PATH', 'QA_RECEIPT_OVERRIDE', 'FLOW_STATE_DIR'):
+                                env.pop(key, None)
+                            env.update(REPO_ROOT=str(root), SPEC_ID='fn-1-smoke', QA_OUTCOME='NA',
+                                       NA_REASON='CLI "quoted"\n雪', FLOWCTL=str(PLUGIN / 'scripts/flowctl'),
+                                       PYTHON_BIN=sys.executable, TMPDIR=str(root),
+                                       QA_FINDINGS='[]', OPEN_P0P1='[]')
+                            if value is not None:
+                                env['RID_COVERAGE'] = value
+                            subprocess.run([sys.executable, str(PLUGIN / 'scripts/flowctl.py'), 'init'],
+                                           cwd=root, env=env, check=True, capture_output=True)
+                            result = subprocess.run([shell, '-c', 'set -e\n' + block], cwd=root,
+                                                    env=env, capture_output=True, text=True)
+                            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                            receipt = json.loads((root / '.flow/review-receipts/qa-fn-1-smoke.json').read_text())
+                            self.assertEqual(receipt['rid_coverage'], coverage if value else {})
+                            self.assertEqual(receipt['qa_outcome'], 'NA')
+                            self.assertEqual(receipt['verdict'], 'SHIP')
+                            self.assertEqual(receipt['na_reason'], env['NA_REASON'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I fixed QA receipt writing so populated requirement coverage remains valid JSON. Empty or unset coverage still uses the existing empty-object fallback. The regression exercises the real canonical and Codex shell writers in Bash and Zsh.

This prepares patch release 4.18.1. Local validation passed 4,843 tests with zero failures/errors and six skips, plus Ruff, documentation anchors and idempotent mirror generation. The full cross-platform run for this exact commit also passed: https://github.com/gmickel/flow-next/actions/runs/34528231921.

The patch stays in the technical changelog; the documentation highlights continue to lead with 4.18.0 and its improved route recommendations.
