### PR TITLE
fix(plan-review): task decomposition is never a finding (5.1.1)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "flow-next",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "source": {
         "source": "local",
         "path": "./plugins/flow-next"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Plan-first workflows for Claude Code and Factory Droid. Ships flow-next: zero-dep, spec-driven, Ralph autonomous mode.",
-    "version": "5.1.0"
+    "version": "5.1.1"
   },
   "plugins": [
     {
       "name": "flow-next",
       "description": "Zero-dependency, spec-driven agentic SDLC: durable specs, context-fit plans, re-anchored workers, adversarial cross-model review, and receipts. Includes 21 subagents, 29 commands, 33 skills.",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "author": {
         "name": "Gordon Mickel",
         "email": "gordon@mickel.tech",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the flow-next.
 
+## [flow-next 5.1.1] - 2026-09-12
+
+Plan review no longer asks for a task split. A spec with zero tasks or one owner task is the default route, so the reviewer's job is the spec's content and, when task specs exist, their consistency with it.
+
+### Changed
+- **Plan review treats task decomposition as the owner's decision.** The shared review prompt and the RepoPrompt prompt state that task count, decomposition, and dispatch shape are never a finding; the consistency and `Touches` checks apply only when task specs are supplied; a missing approach order or test sequence stays a spec-content finding that the owner resolves without a prescribed split.
+
 ## [flow-next 5.1.0] - 2026-09-12
 
 Teams that run Flow-Next unattended get one driver instead of two. One `/flow-next:flow --auto` invocation carries a ready spec to a draft PR, hop after hop, classifying each hop from the same routing references the attended conductor reads, so the route you see in `--explain` is the route the unattended run takes. Pilot users keep working through the alias for one release. `/flow-next:pilot` is retired in 5.1.0, forwards to `flow --auto --tick` with one deprecation line, and the release after 5.1.0 removes it.

--- a/plugins/flow-next/.claude-plugin/plugin.json
+++ b/plugins/flow-next/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Zero-dependency, spec-driven agentic SDLC: durable specs, context-fit plans, re-anchored workers, adversarial cross-model review, and receipts. Includes 21 subagents, 29 commands, 33 skills.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.codex-plugin/plugin.json
+++ b/plugins/flow-next/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Zero-dependency, spec-driven agentic SDLC: durable specs, context-fit plans, re-anchored workers, adversarial cross-model review, and receipts. Compatible with Codex, Claude Code, and Factory Droid.",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/.cursor-plugin/plugin.json
+++ b/plugins/flow-next/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-next",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Zero-dependency, spec-driven agentic SDLC: durable specs, context-fit plans, re-anchored workers, adversarial cross-model review, and receipts. (Ralph autonomous mode is available on other hosts; intentionally not registered on Cursor.)",
   "author": {
     "name": "Gordon Mickel",

--- a/plugins/flow-next/codex/skills/flow-next-plan-review/references/plan-review-prompt.md
+++ b/plugins/flow-next/codex/skills/flow-next-plan-review/references/plan-review-prompt.md
@@ -35,9 +35,11 @@ Conduct a John Carmack-level review of this plan.
 
 You are reviewing:
 1. **Epic spec** in `<spec>` - The high-level plan
-2. **Task specs** in `<task_specs>` - Individual task breakdowns (if provided)
+2. **Task specs** in `<task_specs>` - Individual task breakdowns, when the plan carries any
 
-**CRITICAL**: Check for consistency between epic and tasks. Flag if:
+Task count, task decomposition, and dispatch shape are the owner's and the orchestrator's decisions, never a finding. A spec with zero tasks or one owner task is the default route. Review the spec's content, and review the task specs only for consistency with it when they are supplied.
+
+**CRITICAL** when task specs are supplied: check for consistency between epic and tasks. Flag if:
 - Task specs contradict or miss epic requirements
 - Task acceptance criteria don't align with epic acceptance criteria
 - Task approaches would need to change based on epic design decisions
@@ -50,9 +52,9 @@ You are reviewing:
 3. **Clarity** - Specs unambiguous? Acceptance criteria testable?
 4. **Architecture** - Right abstractions? Clean boundaries?
 5. **Risks** - Blockers identified? Security gaps? Mitigation?
-6. **Scope** - Right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
+6. **Scope** - Is the requirement right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
 7. **Testability** - How will we verify this works?
-8. **Consistency** - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)? On a multi-task spec, a dep-independent task missing its `**Touches:**` line is a finding to flag (omission silently forces serial dispatch; the plan skill mandates the line on every task — uncertain → declare WIDER, never omit).
+8. **Consistency** (only when task specs are supplied) - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)? On a multi-task spec, a dep-independent task missing its `**Touches:**` line is a finding to flag (omission silently forces serial dispatch; the plan skill mandates the line on every task — uncertain → declare WIDER, never omit).
 
 ## Verdict Scope
 
@@ -60,7 +62,9 @@ Explore the codebase to understand context, but your VERDICT must only consider:
 - Issues **within this plan** that block implementation
 - Feasibility problems given the **current codebase state**
 - Missing requirements that are **part of the stated goal**
-- Inconsistencies between epic and task specs
+- Inconsistencies between epic and task specs, when task specs are supplied
+
+A missing approach order or test sequence is a spec-content finding. Whether that gap changes the task split is the owner's call; do not prescribe a split.
 
 Do NOT mark NEEDS_WORK for:
 - Pre-existing codebase issues unrelated to this plan

--- a/plugins/flow-next/codex/skills/flow-next-plan-review/workflow-rp.md
+++ b/plugins/flow-next/codex/skills/flow-next-plan-review/workflow-rp.md
@@ -195,9 +195,11 @@ cat >> "$PROMPT_FILE" <<'EOF'
 
 You are reviewing:
 1. **Spec** - The high-level plan
-2. **Task specs** - Individual task breakdowns
+2. **Task specs** - Individual task breakdowns, when the plan carries any
 
-**CRITICAL**: Check for consistency between spec and tasks. Flag if:
+Task count, task decomposition, and dispatch shape are the owner's and the orchestrator's decisions, never a finding. A spec with zero tasks or one owner task is the default route. Review the spec's content, and review the task specs only for consistency with it when they are supplied.
+
+**CRITICAL** when task specs are supplied: check for consistency between spec and tasks. Flag if:
 - Task specs contradict or miss spec requirements
 - Task acceptance criteria don't align with spec acceptance criteria
 - Task approaches would need to change based on spec design decisions
@@ -213,7 +215,7 @@ Conduct a John Carmack-level review:
 4. **Clarity** - Specs unambiguous? Acceptance criteria testable?
 5. **Architecture** - Right abstractions? Clean boundaries?
 6. **Risks** - Blockers identified? Security gaps? Mitigation?
-7. **Scope** - Right-sized? Over/under-engineering? Overengineering is a
+7. **Scope** - Is the requirement right-sized? Over/under-engineering? Overengineering is a
    FINDING, not a taste note: flag (a) any task or surface not traceable to a
    stated requirement (extra commands, export/import paths, detection hooks,
    config knobs "for later"); (b) risk-management machinery (trust/consent
@@ -227,7 +229,7 @@ Conduct a John Carmack-level review:
    forced excludes of runtime state).
 8. **Task sizing** - M tasks preferred. Flag over-splitting: 7+ tasks? Sequential S tasks that should be combined?
 9. **Testability** - How will we verify this works?
-10. **Consistency** - Do task specs align with spec?
+10. **Consistency** (only when task specs are supplied) - Do task specs align with spec?
 11. **Vocabulary** - [Include ONLY when `flowctl glossary list --json` reports `total_terms > 0`: "Canonical vocabulary lives in GLOSSARY.md — flag specs/tasks that contradict defined terms." Omit this line otherwise.]
 
 **Also explicitly verify (commonly-missed):** a stated **test strategy**; **observability** (logging/metrics/progress) for any async/batch work; each task **sized for one iteration and correctly ordered** by dependency; and stated **non-functional requirements** (performance, security, privacy).

--- a/plugins/flow-next/scripts/flowctl.py
+++ b/plugins/flow-next/scripts/flowctl.py
@@ -9627,9 +9627,11 @@ Conduct a John Carmack-level review of this plan.
 
 You are reviewing:
 1. **Epic spec** in `<spec>` - The high-level plan
-2. **Task specs** in `<task_specs>` - Individual task breakdowns (if provided)
+2. **Task specs** in `<task_specs>` - Individual task breakdowns, when the plan carries any
 
-**CRITICAL**: Check for consistency between epic and tasks. Flag if:
+Task count, task decomposition, and dispatch shape are the owner's and the orchestrator's decisions, never a finding. A spec with zero tasks or one owner task is the default route. Review the spec's content, and review the task specs only for consistency with it when they are supplied.
+
+**CRITICAL** when task specs are supplied: check for consistency between epic and tasks. Flag if:
 - Task specs contradict or miss epic requirements
 - Task acceptance criteria don't align with epic acceptance criteria
 - Task approaches would need to change based on epic design decisions
@@ -9642,9 +9644,9 @@ You are reviewing:
 3. **Clarity** - Specs unambiguous? Acceptance criteria testable?
 4. **Architecture** - Right abstractions? Clean boundaries?
 5. **Risks** - Blockers identified? Security gaps? Mitigation?
-6. **Scope** - Right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
+6. **Scope** - Is the requirement right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
 7. **Testability** - How will we verify this works?
-8. **Consistency** - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)? On a multi-task spec, a dep-independent task missing its `**Touches:**` line is a finding to flag (omission silently forces serial dispatch; the plan skill mandates the line on every task — uncertain → declare WIDER, never omit).
+8. **Consistency** (only when task specs are supplied) - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)? On a multi-task spec, a dep-independent task missing its `**Touches:**` line is a finding to flag (omission silently forces serial dispatch; the plan skill mandates the line on every task — uncertain → declare WIDER, never omit).
 
 ## Verdict Scope
 
@@ -9652,7 +9654,9 @@ Explore the codebase to understand context, but your VERDICT must only consider:
 - Issues **within this plan** that block implementation
 - Feasibility problems given the **current codebase state**
 - Missing requirements that are **part of the stated goal**
-- Inconsistencies between epic and task specs
+- Inconsistencies between epic and task specs, when task specs are supplied
+
+A missing approach order or test sequence is a spec-content finding. Whether that gap changes the task split is the owner's call; do not prescribe a split.
 
 Do NOT mark NEEDS_WORK for:
 - Pre-existing codebase issues unrelated to this plan

--- a/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
+++ b/plugins/flow-next/scripts/flowctl_tracker/MANIFEST.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "flowctl.py",
-      "sha256": "9e541ae7f43f143860b3a26271379eb0266017cbda3a13d4c98f8d92b2df6e79"
+      "sha256": "370e6ef8dd7d8452a683997e509c5b6ae5209ce428632fa26ca8682d2d20871a"
     },
     {
       "path": "flowctl_tracker/__init__.py",

--- a/plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md
@@ -35,9 +35,11 @@ Conduct a John Carmack-level review of this plan.
 
 You are reviewing:
 1. **Epic spec** in `<spec>` - The high-level plan
-2. **Task specs** in `<task_specs>` - Individual task breakdowns (if provided)
+2. **Task specs** in `<task_specs>` - Individual task breakdowns, when the plan carries any
 
-**CRITICAL**: Check for consistency between epic and tasks. Flag if:
+Task count, task decomposition, and dispatch shape are the owner's and the orchestrator's decisions, never a finding. A spec with zero tasks or one owner task is the default route. Review the spec's content, and review the task specs only for consistency with it when they are supplied.
+
+**CRITICAL** when task specs are supplied: check for consistency between epic and tasks. Flag if:
 - Task specs contradict or miss epic requirements
 - Task acceptance criteria don't align with epic acceptance criteria
 - Task approaches would need to change based on epic design decisions
@@ -50,9 +52,9 @@ You are reviewing:
 3. **Clarity** - Specs unambiguous? Acceptance criteria testable?
 4. **Architecture** - Right abstractions? Clean boundaries?
 5. **Risks** - Blockers identified? Security gaps? Mitigation?
-6. **Scope** - Right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
+6. **Scope** - Is the requirement right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
 7. **Testability** - How will we verify this works?
-8. **Consistency** - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)? On a multi-task spec, a dep-independent task missing its `**Touches:**` line is a finding to flag (omission silently forces serial dispatch; the plan skill mandates the line on every task — uncertain → declare WIDER, never omit).
+8. **Consistency** (only when task specs are supplied) - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)? On a multi-task spec, a dep-independent task missing its `**Touches:**` line is a finding to flag (omission silently forces serial dispatch; the plan skill mandates the line on every task — uncertain → declare WIDER, never omit).
 
 ## Verdict Scope
 
@@ -60,7 +62,9 @@ Explore the codebase to understand context, but your VERDICT must only consider:
 - Issues **within this plan** that block implementation
 - Feasibility problems given the **current codebase state**
 - Missing requirements that are **part of the stated goal**
-- Inconsistencies between epic and task specs
+- Inconsistencies between epic and task specs, when task specs are supplied
+
+A missing approach order or test sequence is a spec-content finding. Whether that gap changes the task split is the owner's call; do not prescribe a split.
 
 Do NOT mark NEEDS_WORK for:
 - Pre-existing codebase issues unrelated to this plan

--- a/plugins/flow-next/skills/flow-next-plan-review/workflow-rp.md
+++ b/plugins/flow-next/skills/flow-next-plan-review/workflow-rp.md
@@ -168,9 +168,11 @@ cat >> "$PROMPT_FILE" <<'EOF'
 
 You are reviewing:
 1. **Spec** - The high-level plan
-2. **Task specs** - Individual task breakdowns
+2. **Task specs** - Individual task breakdowns, when the plan carries any
 
-**CRITICAL**: Check for consistency between spec and tasks. Flag if:
+Task count, task decomposition, and dispatch shape are the owner's and the orchestrator's decisions, never a finding. A spec with zero tasks or one owner task is the default route. Review the spec's content, and review the task specs only for consistency with it when they are supplied.
+
+**CRITICAL** when task specs are supplied: check for consistency between spec and tasks. Flag if:
 - Task specs contradict or miss spec requirements
 - Task acceptance criteria don't align with spec acceptance criteria
 - Task approaches would need to change based on spec design decisions
@@ -186,7 +188,7 @@ Conduct a John Carmack-level review:
 4. **Clarity** - Specs unambiguous? Acceptance criteria testable?
 5. **Architecture** - Right abstractions? Clean boundaries?
 6. **Risks** - Blockers identified? Security gaps? Mitigation?
-7. **Scope** - Right-sized? Over/under-engineering? Overengineering is a
+7. **Scope** - Is the requirement right-sized? Over/under-engineering? Overengineering is a
    FINDING, not a taste note: flag (a) any task or surface not traceable to a
    stated requirement (extra commands, export/import paths, detection hooks,
    config knobs "for later"); (b) risk-management machinery (trust/consent
@@ -200,7 +202,7 @@ Conduct a John Carmack-level review:
    forced excludes of runtime state).
 8. **Task sizing** - M tasks preferred. Flag over-splitting: 7+ tasks? Sequential S tasks that should be combined?
 9. **Testability** - How will we verify this works?
-10. **Consistency** - Do task specs align with spec?
+10. **Consistency** (only when task specs are supplied) - Do task specs align with spec?
 11. **Vocabulary** - [Include ONLY when `flowctl glossary list --json` reports `total_terms > 0`: "Canonical vocabulary lives in GLOSSARY.md — flag specs/tasks that contradict defined terms." Omit this line otherwise.]
 
 **Also explicitly verify (commonly-missed):** a stated **test strategy**; **observability** (logging/metrics/progress) for any async/batch work; each task **sized for one iteration and correctly ordered** by dependency; and stated **non-functional requirements** (performance, security, privacy).

--- a/plugins/flow-next/tests/fixtures/review_prompts/plan.txt
+++ b/plugins/flow-next/tests/fixtures/review_prompts/plan.txt
@@ -49,9 +49,11 @@ Conduct a John Carmack-level review of this plan.
 
 You are reviewing:
 1. **Epic spec** in `<spec>` - The high-level plan
-2. **Task specs** in `<task_specs>` - Individual task breakdowns (if provided)
+2. **Task specs** in `<task_specs>` - Individual task breakdowns, when the plan carries any
 
-**CRITICAL**: Check for consistency between epic and tasks. Flag if:
+Task count, task decomposition, and dispatch shape are the owner's and the orchestrator's decisions, never a finding. A spec with zero tasks or one owner task is the default route. Review the spec's content, and review the task specs only for consistency with it when they are supplied.
+
+**CRITICAL** when task specs are supplied: check for consistency between epic and tasks. Flag if:
 - Task specs contradict or miss epic requirements
 - Task acceptance criteria don't align with epic acceptance criteria
 - Task approaches would need to change based on epic design decisions
@@ -64,9 +66,9 @@ You are reviewing:
 3. **Clarity** - Specs unambiguous? Acceptance criteria testable?
 4. **Architecture** - Right abstractions? Clean boundaries?
 5. **Risks** - Blockers identified? Security gaps? Mitigation?
-6. **Scope** - Right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
+6. **Scope** - Is the requirement right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
 7. **Testability** - How will we verify this works?
-8. **Consistency** - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)? On a multi-task spec, a dep-independent task missing its `**Touches:**` line is a finding to flag (omission silently forces serial dispatch; the plan skill mandates the line on every task — uncertain → declare WIDER, never omit).
+8. **Consistency** (only when task specs are supplied) - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)? On a multi-task spec, a dep-independent task missing its `**Touches:**` line is a finding to flag (omission silently forces serial dispatch; the plan skill mandates the line on every task — uncertain → declare WIDER, never omit).
 
 ## Verdict Scope
 
@@ -74,7 +76,9 @@ Explore the codebase to understand context, but your VERDICT must only consider:
 - Issues **within this plan** that block implementation
 - Feasibility problems given the **current codebase state**
 - Missing requirements that are **part of the stated goal**
-- Inconsistencies between epic and task specs
+- Inconsistencies between epic and task specs, when task specs are supplied
+
+A missing approach order or test sequence is a spec-content finding. Whether that gap changes the task split is the owner's call; do not prescribe a split.
 
 Do NOT mark NEEDS_WORK for:
 - Pre-existing codebase issues unrelated to this plan

--- a/plugins/flow-next/tests/fixtures/review_prompts/plan_no_tasks.txt
+++ b/plugins/flow-next/tests/fixtures/review_prompts/plan_no_tasks.txt
@@ -44,9 +44,11 @@ Conduct a John Carmack-level review of this plan.
 
 You are reviewing:
 1. **Epic spec** in `<spec>` - The high-level plan
-2. **Task specs** in `<task_specs>` - Individual task breakdowns (if provided)
+2. **Task specs** in `<task_specs>` - Individual task breakdowns, when the plan carries any
 
-**CRITICAL**: Check for consistency between epic and tasks. Flag if:
+Task count, task decomposition, and dispatch shape are the owner's and the orchestrator's decisions, never a finding. A spec with zero tasks or one owner task is the default route. Review the spec's content, and review the task specs only for consistency with it when they are supplied.
+
+**CRITICAL** when task specs are supplied: check for consistency between epic and tasks. Flag if:
 - Task specs contradict or miss epic requirements
 - Task acceptance criteria don't align with epic acceptance criteria
 - Task approaches would need to change based on epic design decisions
@@ -59,9 +61,9 @@ You are reviewing:
 3. **Clarity** - Specs unambiguous? Acceptance criteria testable?
 4. **Architecture** - Right abstractions? Clean boundaries?
 5. **Risks** - Blockers identified? Security gaps? Mitigation?
-6. **Scope** - Right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
+6. **Scope** - Is the requirement right-sized? Over/under-engineering? Overengineering is a FINDING, not a taste note: flag (a) any task or surface not traceable to a stated requirement (extra commands, export/import paths, detection hooks, config knobs "for later"); (b) risk-management machinery (trust/consent layers, caps, scanners, secondary state stores) where the risk could be eliminated structurally (closed schema, inert format, capability not exposed); (c) N-way generality where the request names one concrete case. Scope-minimality never trims rigor: error/negative-case enumeration per AC must stay complete — flag the plan if minimality was achieved by dropping error handling or by dropping filesystem-identity, permission, or concurrency guards (realpath/symlink containment, lock-guarded writes, forced excludes of runtime state).
 7. **Testability** - How will we verify this works?
-8. **Consistency** - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)? On a multi-task spec, a dep-independent task missing its `**Touches:**` line is a finding to flag (omission silently forces serial dispatch; the plan skill mandates the line on every task — uncertain → declare WIDER, never omit).
+8. **Consistency** (only when task specs are supplied) - Do task specs align with epic spec? Are `**Touches:**` declarations plausible against each task's Files/Approach, and do any two dep-independent tasks' Touches sets overlap (overlaps force serial dispatch - flag the pair)? On a multi-task spec, a dep-independent task missing its `**Touches:**` line is a finding to flag (omission silently forces serial dispatch; the plan skill mandates the line on every task — uncertain → declare WIDER, never omit).
 
 ## Verdict Scope
 
@@ -69,7 +71,9 @@ Explore the codebase to understand context, but your VERDICT must only consider:
 - Issues **within this plan** that block implementation
 - Feasibility problems given the **current codebase state**
 - Missing requirements that are **part of the stated goal**
-- Inconsistencies between epic and task specs
+- Inconsistencies between epic and task specs, when task specs are supplied
+
+A missing approach order or test sequence is a spec-content finding. Whether that gap changes the task split is the owner's call; do not prescribe a split.
 
 Do NOT mark NEEDS_WORK for:
 - Pre-existing codebase issues unrelated to this plan

--- a/plugins/flow-next/tests/test_prompt_text_pinned.py
+++ b/plugins/flow-next/tests/test_prompt_text_pinned.py
@@ -102,7 +102,7 @@ PROMPT_HASHES = {
     "PLAN_QUALITY_BLOCK":
         "0cfb49bfadf0be45e5c8036950d34698b5ae3bbccf24a90564983e13d0a1192f",
     "PLAN_REVIEW_PROMPT_FALLBACK":
-        "dfef7509111bbaac438d85149a84ee3fc85bf407b3e499605d554bad9a8664fb",
+        "b967175115a95cd44ba7ef3a800733c279e45d63d05fa9c46fcc84f938e91f93",
     "PROTECTED_ARTIFACTS_BLOCK":
         "e9b68af0cf36f6b2cb1b70c9bcc5ff67ccb86295f369d02ffcec4f25fd6f2d5e",
     "REVIEW_JSON_TALLY_BLOCK":
@@ -196,7 +196,7 @@ TEMPLATE_HASHES = {
     "plugins/flow-next/skills/flow-next-impl-review/references/standalone-review-prompt.md":
         "beedb8d647f78d782b3e58ebdeb8cbace8ae7dcb5b9e432359a6627a9a255963",
     "plugins/flow-next/skills/flow-next-plan-review/references/plan-review-prompt.md":
-        "dfef7509111bbaac438d85149a84ee3fc85bf407b3e499605d554bad9a8664fb",
+        "b967175115a95cd44ba7ef3a800733c279e45d63d05fa9c46fcc84f938e91f93",
     "plugins/flow-next/skills/flow-next-spec-completion-review/references/completion-review-prompt.md":
         "a4b3105a7a8a3a56ba21d035d89dfc5cc62a496f4e1317b00fa89b01e197aafc",
     # Rendered by ralph.sh each autonomous loop - production prompts, and the


### PR DESCRIPTION
Plan review's shared prompt and the RepoPrompt prompt no longer read a single-owner or zero-task spec as under-decomposed. Task count, decomposition, and dispatch shape are stated as the owner's and orchestrator's decisions; the consistency and Touches checks apply only when task specs are supplied; a missing approach order or test sequence stays a spec-content finding without a prescribed split. Patch release 5.1.1 bundled.

https://claude.ai/code/session_01HcGWrFE4oDwPn5YcFQVG84